### PR TITLE
Logging

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -17,5 +17,9 @@ PATIENCE = 4  # patience for early stopping
 # GPU
 GPU_MEMORY_LIMIT_MB = 4096
 
+# Logging
+INFO_LOGGING_FILE_NAME = "info.log"
+DEBUG_LOGGING_FILE_NAME = "debug.log"
+
 # Contributivity methods names
 # TODO

--- a/main.py
+++ b/main.py
@@ -25,8 +25,8 @@ import argparse
 
 DEFAULT_CONFIG_FILE = "config.yml"
 
-class StreamToLogger:
 
+class StreamToLogger:
     def __init__(self, level="INFO"):
         self._level = level
 
@@ -53,8 +53,12 @@ def main():
         n_repeats = config["n_repeats"]
 
         # Move log files to experiment folder
-        move_log_file_to_experiment_folder(info_logger_id, experiment_path, constants.INFO_LOGGING_FILE_NAME)
-        move_log_file_to_experiment_folder(info_debug_id, experiment_path, constants.DEBUG_LOGGING_FILE_NAME)
+        move_log_file_to_experiment_folder(
+            info_logger_id, experiment_path, constants.INFO_LOGGING_FILE_NAME
+        )
+        move_log_file_to_experiment_folder(
+            info_debug_id, experiment_path, constants.DEBUG_LOGGING_FILE_NAME
+        )
 
         # GPU config
         init_GPU_config()
@@ -90,14 +94,15 @@ def main():
 
     return 0
 
+
 def init_logger():
     logger.remove()
     # Forward all logging to standart output
-    logger.add(sys.__stdout__, level='DEBUG')
+    logger.add(sys.__stdout__, level="DEBUG")
     stream = StreamToLogger()
 
-    info_logger_id = logger.add(constants.INFO_LOGGING_FILE_NAME, level='INFO')
-    info_debug_id = logger.add(constants.DEBUG_LOGGING_FILE_NAME, level='DEBUG')
+    info_logger_id = logger.add(constants.INFO_LOGGING_FILE_NAME, level="INFO")
+    info_debug_id = logger.add(constants.DEBUG_LOGGING_FILE_NAME, level="DEBUG")
     return stream, info_logger_id, info_debug_id
 
 
@@ -150,6 +155,7 @@ def run_scenario(current_scenario):
 
     return 0
 
+
 def get_config_from_file():
     parser = argparse.ArgumentParser()
     parser.add_argument("-f", "--file", help="input config file")
@@ -165,6 +171,7 @@ def get_config_from_file():
     config = utils.init_result_folder(config_filepath, config)
 
     return config
+
 
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -37,10 +37,8 @@ def main():
         config = get_config_from_file()
         scenario_params_list = utils.get_scenario_params_list(
             config["scenario_params_list"])
-        
-        n_repeats = config["n_repeats"]
+
         experiment_path = config["experiment_path"]
-        scenario_params_list = config["scenario_params_list"]
         n_repeats = config["n_repeats"]
         
         print('Scenarii to process: ', )

--- a/main.py
+++ b/main.py
@@ -12,7 +12,8 @@ import numpy as np
 import utils
 from loguru import logger
 import tensorflow as tf
-
+import sys
+import contextlib
 
 import constants
 import contributivity
@@ -23,8 +24,29 @@ import argparse
 
 DEFAULT_CONFIG_FILE = "config.yml"
 
+class StreamToLogger:
+
+    def __init__(self, level="INFO"):
+        self._level = level
+
+    def write(self, buffer):
+        for line in buffer.rstrip().splitlines():
+            logger.opt(depth=1).log(self._level, line.rstrip())
+
+    def flush(self):
+        pass
+
 
 def main():
+
+    logger.remove()
+    logger.add(sys.__stdout__)
+    stream = StreamToLogger()
+
+    logger.add("experiment.log")
+
+    with contextlib.redirect_stdout(stream):
+        print("Standard output is sent to added handlers.")
 
     # Parse config file for scenarios to be experimented
     parser = argparse.ArgumentParser()

--- a/main.py
+++ b/main.py
@@ -26,18 +26,6 @@ import argparse
 DEFAULT_CONFIG_FILE = "config.yml"
 
 
-class StreamToLogger:
-    def __init__(self, level="INFO"):
-        self._level = level
-
-    def write(self, buffer):
-        for line in buffer.rstrip().splitlines():
-            logger.opt(depth=1).log(self._level, line.rstrip())
-
-    def flush(self):
-        pass
-
-
 def main():
 
     stream, info_logger_id, info_debug_id = init_logger()
@@ -171,6 +159,18 @@ def get_config_from_file():
     config = utils.init_result_folder(config_filepath, config)
 
     return config
+
+
+class StreamToLogger:
+    def __init__(self, level="INFO"):
+        self._level = level
+
+    def write(self, buffer):
+        for line in buffer.rstrip().splitlines():
+            logger.opt(depth=1).log(self._level, line.rstrip())
+
+    def flush(self):
+        pass
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -53,8 +53,8 @@ def main():
         n_repeats = config["n_repeats"]
 
         # Move log files to experiment folder
-        move_log_file_to_experiment_folder(info_logger_id, experiment_path)
-        move_log_file_to_experiment_folder(info_debug_id, experiment_path)
+        move_log_file_to_experiment_folder(info_logger_id, experiment_path, constants.INFO_LOGGING_FILE_NAME)
+        move_log_file_to_experiment_folder(info_debug_id, experiment_path, constants.DEBUG_LOGGING_FILE_NAME)
 
         # GPU config
         init_GPU_config()
@@ -113,10 +113,10 @@ def init_GPU_config():
         logger.info("No GPU found")
 
 
-def move_log_file_to_experiment_folder(logger_id, experiment_path):
+def move_log_file_to_experiment_folder(logger_id, experiment_path, filename):
     logger.remove(logger_id)
-    new_log_path =  experiment_path / constants.INFO_LOGGING_FILE_NAME
-    shutil.move(constants.INFO_LOGGING_FILE_NAME, new_log_path)
+    new_log_path = experiment_path / filename
+    shutil.move(filename, new_log_path)
     logger.add(new_log_path)
 
 

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ import argparse
 
 DEFAULT_CONFIG_FILE = "config.yml"
 
-
+@logger.catch
 def main():
 
     stream, info_logger_id, info_debug_id = init_logger()


### PR DESCRIPTION
Fixes #32 
Create two logs files : 
- one for logs level INFO and above
- one for logs level DEBUG and above

Log files are created at the root folder. When the experiment folder is created, logs files are moved to this folder.

stdout and exceptions are logged. So any print() is logged but we would have to change them to logger.info() or logger.debug() / warning() ... for better clarity --> https://github.com/SubstraFoundation/distributed-learning-contributivity/issues/123
Tensorflow messages are not logged. I created an issue for that --> https://github.com/SubstraFoundation/distributed-learning-contributivity/issues/122


Logging is done with Loguru : https://github.com/Delgan/loguru