### PR TITLE
Housekeeping! (clean samples_split_option, clean local val and test sets, misc. minor improvements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Finally, with given scenarios and multi-partner learning approaches, we can addr
        amounts_per_partner: 
          - [0.4, 0.3, 0.3]
        samples_split_option: 
-         - [[7, 'shared'], [6, 'shared'], [2, 'specific']]
+         - ['advanced', [[7, 'shared'], [6, 'shared'], [2, 'specific']]]
        multi_partner_learning_approach:
          - 'fedavg'
        aggregation_weighting: 
@@ -94,8 +94,8 @@ Finally, with given scenarios and multi-partner learning approaches, we can addr
        amounts_per_partner: 
          - [0.5, 0.5]
        samples_split_option: 
-         - 'random'
-         - 'stratified'
+         - ['basic', 'random']
+         - ['basic', 'stratified']
        multi_partner_learning_approach:
          - 'fedavg'
        aggregation_weighting: 
@@ -148,18 +148,19 @@ Example: `partners_count: 4`
 Fractions of the original dataset each partner receives to mock a collaborative ML scenario where each partner provides data for the ML training.  
 Example: `amounts_per_partner: [0.3, 0.3, 0.1, 0.3]`
 
-`samples_split_option`: `'random'` (default), `'stratified'` or `[[nb of clusters (int), 'shared' or 'specific']]`   
+`samples_split_option`: `['basic', 'random']` (default), `['basic', 'stratified']` or `['advanced', [[nb of clusters (int), 'shared' or 'specific']]]`   
 How the original dataset data samples are split among partners:
 
-- `'random'`: the dataset is shuffled and partners receive data samples selected randomly
-- `'stratified'`: the dataset is stratified per class and each partner receives certain classes only (note: depending on the `amounts_per_partner` specified, there might be small overlaps of classes)
-- `[[nb of clusters (int), 'shared' or 'specific']]`: in certain cases it might be interesting to split the dataset among partners in a more elaborate way. For that we consider the data samples from the initial dataset as split in clusters per data labels. The advanced split is configured by indicating, for each partner in sequence, the following 2 elements:
+- `'basic'` approaches:
+  - `'random'`: the dataset is shuffled and partners receive data samples selected randomly
+  - `'stratified'`: the dataset is stratified per class and each partner receives certain classes only (note: depending on the `amounts_per_partner` specified, there might be small overlaps of classes)
+- `'advanced'` approach `[[nb of clusters (int), 'shared' or 'specific']]`: in certain cases it might be interesting to split the dataset among partners in a more elaborate way. For that we consider the data samples from the initial dataset as split in clusters per data labels. The advanced split is configured by indicating, for each partner in sequence, the following 2 elements:
   - `nb of clusters (int)`: the given partner will receive data samples from that many different clusters (clusters of data samples per labels/classes) 
   - `'shared'` or `'specific'`:
     - `'shared'`: all partners with option `'shared'` receive data samples picked from clusters they all share data samples from
     - `'specific'`: each partner with option `'specific'` receives data samples picked from cluster(s) it is the only one to receive from
 
-Example: `[[7, 'shared'], [6, 'shared'], [2, 'specific'], [1, 'specific']]`
+Example: `['advanced', [[7, 'shared'], [6, 'shared'], [2, 'specific'], [1, 'specific']]]`
 
 ![Example of the advanced split option](img/advanced_split_example.png)
 

--- a/README.md
+++ b/README.md
@@ -219,13 +219,9 @@ Example: `gradient_updates_per_pass_count: 5`
 
 `is_early_stopping`: `True` (default) or `False`  
 When set to `True`, the training phases (whether multi-partner of single-partner) are stopped when the performance on the validation set reaches a plateau.  
-Example: `is_early_stopping: False`
- 
-`single_partner_test_mode`: `'global'` (default) or `'local'`  
-When training a model on a single partner (this is needed in certain contributivity measurement approaches), defines if the final performance is tested on the central testset or on the partner's local testset. Note: a train-test split is performed on the original dataset, forming a central testset; this testset is also split over each partner (randomly) forming local testsets. This is currently not very useful, but might be interesting with future improvements of this library.  
-Example: `single_partner_test_mode: 'global'`  
+Example: `is_early_stopping: False` 
 
-**Note:** to only launch the distributed learning on the scenarios (and no contributivity measurement methods), omit the `methods` parameter (see section [Configuration of contributivity measurement methods to be tested](#configuration-of-contributivity-measurement-methods-to-be-tested) below).
+**Note:** to only launch the distributed learning on the scenarios (and no contributivity measurement methods), simply omit the `methods` parameter (see section [Configuration of contributivity measurement methods to be tested](#configuration-of-contributivity-measurement-methods-to-be-tested) below).
 
 ##### Configuration of contributivity measurement methods to be tested
 

--- a/config.yml
+++ b/config.yml
@@ -9,8 +9,9 @@ scenario_params_list:
    amounts_per_partner: 
      - [0.4, 0.3, 0.3]
    samples_split_option: 
-     - 'random'
-     - 'stratified'
+     - ['basic', 'random']
+     - ['basic', 'stratified']
+     - ['advanced', [[4, 'shared'], [6, 'shared'], [4, 'specific']]]
    multi_partner_learning_approach:
      - 'fedavg'
      - 'seq-pure'
@@ -33,9 +34,8 @@ scenario_params_list:
      - 2
    amounts_per_partner: 
      - [0.5, 0.5]
-   samples_split_option: 
-     - 'random'
-     - 'stratified'
+   samples_split_option:
+     - ['basic', 'stratified']
    multi_partner_learning_approach:
      - 'fedavg'
    aggregation_weighting: 

--- a/config_quick_debug.yml
+++ b/config_quick_debug.yml
@@ -8,8 +8,8 @@ scenario_params_list:
     - 3
    amounts_per_partner: 
     - [0.2, 0.5, 0.3]
-   samples_split_option: 
-    - 'random'
+   samples_split_option:
+    - ['advanced', [[4, 'shared'], [6, 'shared'], [4, 'specific']]]
    multi_partner_learning_approach:
     - 'fedavg'
    aggregation_weighting:

--- a/contributivity.py
+++ b/contributivity.py
@@ -110,7 +110,6 @@ class Contributivity:
                 the_scenario.dataset,
                 the_scenario.multi_partner_learning_approach,
                 the_scenario.aggregation_weighting,
-                the_scenario.single_partner_test_mode,
                 is_early_stopping=True,
                 is_save_data=False,
                 save_folder=the_scenario.save_folder,

--- a/main.py
+++ b/main.py
@@ -137,7 +137,7 @@ def validate_scenario_list(scenario_params_list, experiment_path):
         current_scenario = scenario.Scenario(scenario_params, experiment_path, is_dry_run=True)
         current_scenario.instantiate_scenario_partners()
 
-        if isinstance(current_scenario.samples_split_option, list):
+        if isinstance(current_scenario.samples_split_description, list):
             current_scenario.split_data_advanced(is_logging_enabled=False)
         else:
             current_scenario.split_data(is_logging_enabled=False)        
@@ -150,10 +150,10 @@ def run_scenario(current_scenario):
     current_scenario.instantiate_scenario_partners()
     # Split data according to scenario and then pre-process successively...
     # ... train data, early stopping validation data, test data
-    if isinstance(current_scenario.samples_split_option, list):
-        current_scenario.split_data_advanced()
-    else:
+    if current_scenario.samples_split_type == 'basic':
         current_scenario.split_data()
+    elif current_scenario.samples_split_type == 'advanced':
+        current_scenario.split_data_advanced()
     current_scenario.plot_data_distribution()
     current_scenario.compute_batch_sizes()
     current_scenario.preprocess_scenarios_data()

--- a/main.py
+++ b/main.py
@@ -137,10 +137,10 @@ def validate_scenario_list(scenario_params_list, experiment_path):
         current_scenario = scenario.Scenario(scenario_params, experiment_path, is_dry_run=True)
         current_scenario.instantiate_scenario_partners()
 
-        if isinstance(current_scenario.samples_split_description, list):
+        if current_scenario.samples_split_type == 'basic':
+            current_scenario.split_data(is_logging_enabled=False)
+        elif current_scenario.samples_split_type == 'advanced':
             current_scenario.split_data_advanced(is_logging_enabled=False)
-        else:
-            current_scenario.split_data(is_logging_enabled=False)        
 
     logger.debug("All scenario have been validated")
 

--- a/multi_partner_learning.py
+++ b/multi_partner_learning.py
@@ -26,7 +26,6 @@ class MultiPartnerLearning:
                  dataset,
                  multi_partner_learning_approach,
                  aggregation_weighting="uniform",
-                 single_partner_test_mode="global",
                  is_early_stopping=True,
                  is_save_data=False,
                  save_folder="",
@@ -44,7 +43,6 @@ class MultiPartnerLearning:
         # Attributes related to the multi-partner learning approach
         self.learning_approach = multi_partner_learning_approach
         self.aggregation_weighting = aggregation_weighting
-        self.single_partner_test_mode = single_partner_test_mode
 
         # Attributes related to iterating at different levels
         self.epoch_count = epoch_count
@@ -97,13 +95,8 @@ class MultiPartnerLearning:
             callbacks=cb,
         )
 
-        # Reference a testset according to the scenario configuration
-        if self.single_partner_test_mode == "global":
-            x_test, y_test = self.test_data
-        elif self.single_partner_test_mode == "local":
-            x_test, y_test = partner.x_test, partner.y_test
-        else:
-            raise NameError("single_partner_test_mode value '" + self.single_partner_test_mode + "' is not recognized.")
+        # Reference the testset according to the scenario configuration
+        x_test, y_test = self.test_data
 
         # Evaluate trained model
         model_evaluation = model.evaluate(x_test, y_test, batch_size=constants.DEFAULT_BATCH_SIZE, verbose=0)
@@ -534,7 +527,6 @@ def init_multi_partner_learning_from_scenario(scenario, is_save_data=True):
         scenario.dataset,
         scenario.multi_partner_learning_approach,
         scenario.aggregation_weighting,
-        scenario.single_partner_test_mode,
         scenario.is_early_stopping,
         is_save_data,
         scenario.save_folder,

--- a/scenario.py
+++ b/scenario.py
@@ -23,6 +23,10 @@ from partner import Partner
 class Scenario:
     def __init__(self, params, experiment_path, scenario_id=1, n_repeat=1, is_dry_run=False):
 
+        # ---------------------------------------------------------------------
+        # Initialization of the dataset defined in the config of the experiment
+        # ---------------------------------------------------------------------
+
         # Get and verify which dataset is configured
         supported_datasets_names = ["mnist", "cifar10"]
         if "dataset_name" in params:
@@ -59,15 +63,12 @@ class Scenario:
         # The train set has to be split into a train set and a validation set for early stopping
         self.dataset.train_val_split()
 
-        # List of all partners defined in the scenario
-        self.partners_list = []
-
-        # List of contributivity measures selected and computed in the scenario
-        self.contributivity_list = []
-
         # --------------------------------------
         #  Definition of collaborative scenarios
         # --------------------------------------
+
+        # List of all partners defined in the scenario
+        self.partners_list = []
 
         # partners mock different partners in a collaborative data science project
         # For defining the number of partners
@@ -160,6 +161,9 @@ class Scenario:
         # -----------------------------------------------------------------
         #  Configuration of contributivity measurement methods to be tested
         # -----------------------------------------------------------------
+
+        # List of contributivity measures selected and computed in the scenario
+        self.contributivity_list = []
 
         # Contributivity methods
         contributivity_methods_list = [

--- a/scenario.py
+++ b/scenario.py
@@ -591,7 +591,7 @@ class Scenario:
         dict_results["train_data_samples_count"] = len(self.dataset.x_train)
         dict_results["test_data_samples_count"] = len(self.dataset.x_test)
         dict_results["partners_count"] = self.partners_count
-        dict_results["amounts_per_partner"] = self.amounts_per_partner
+        dict_results["dataset_fraction_per_partner"] = self.amounts_per_partner
         dict_results["samples_split_description"] = self.samples_split_description
         dict_results["nb_samples_used"] = self.nb_samples_used
         dict_results["final_relative_nb_samples"] = self.final_relative_nb_samples
@@ -624,7 +624,7 @@ class Scenario:
 
                 # Partner-specific data
                 dict_results["partner_id"] = i
-                dict_results["amount_per_partner"] = self.amounts_per_partner[i]
+                dict_results["dataset_fraction_of_partner"] = self.amounts_per_partner[i]
                 dict_results["contributivity_score"] = contrib.contributivity_scores[i]
                 dict_results["contributivity_std"] = contrib.scores_std[i]
 

--- a/scenario.py
+++ b/scenario.py
@@ -82,9 +82,9 @@ class Scenario:
         # For configuring if data samples are split between partners randomly or in a stratified way...
         # ... so that they cover distinct areas of the samples space
         if "samples_split_option" in params:
-            self.samples_split_option = params["samples_split_option"]
+            (self.samples_split_type, self.samples_split_description) = params["samples_split_option"]
         else:
-            self.samples_split_option = "random"  # default
+            (self.samples_split_type, self.samples_split_description) = ("basic", "random")  # default
 
         # For configuring if the data of the partners are corrupted or not (useful for testing contributivity measures)
         if "corrupted_datasets" in params:
@@ -245,7 +245,7 @@ class Scenario:
             # Describe scenario
             logger.info("### Description of data scenario configured:")
             logger.info(f"   Number of partners defined: {self.partners_count}")
-            logger.info(f"   Data distribution scenario chosen: {self.samples_split_option}")
+            logger.info(f"   Data distribution scenario chosen: {self.samples_split_description}")
             logger.info(f"   Test data distribution scenario chosen: {self.single_partner_test_mode}")
             logger.info(f"   Multi-partner learning approach: {self.multi_partner_learning_approach}")
             logger.info(f"   Weighting option: {self.aggregation_weighting}")
@@ -277,12 +277,12 @@ class Scenario:
         y_test = self.dataset.y_test
         partners_list = self.partners_list
         amounts_per_partner = self.amounts_per_partner
-        advanced_split_option = self.samples_split_option
+        advanced_split_description = self.samples_split_description
 
         # Compose the lists of partners with data samples from shared clusters and those with specific clusters
         for p in partners_list:
-            p.cluster_count = int(advanced_split_option[p.id][0])
-            p.cluster_split_option = advanced_split_option[p.id][1]
+            p.cluster_count = int(advanced_split_description[p.id][0])
+            p.cluster_split_option = advanced_split_description[p.id][1]
         partners_with_shared_clusters = [p for p in partners_list if p.cluster_split_option == 'shared']
         partners_with_specific_clusters = [p for p in partners_list if p.cluster_split_option == 'specific']
         partners_with_shared_clusters.sort(key=operator.attrgetter("cluster_count"), reverse=True)
@@ -432,22 +432,22 @@ class Scenario:
         test_idx = np.arange(len(y_test))
 
         # In the 'stratified' scenario we sort MNIST by labels
-        if self.samples_split_option == "stratified":
+        if self.samples_split_description == "stratified":
             # Sort MNIST by labels
             y_sorted_idx = y_train.argsort()
             y_train = y_train[y_sorted_idx]
             x_train = x_train[y_sorted_idx]
 
         # In the 'random' scenario we shuffle randomly the indexes
-        elif self.samples_split_option == "random":
+        elif self.samples_split_description == "random":
             np.random.seed(42)
             np.random.shuffle(train_idx)
 
         # If neither 'stratified' nor 'random', we raise an exception
         else:
             raise NameError(
-                "This samples_split_option scenario ["
-                + self.samples_split_option
+                "This samples_split option ["
+                + self.samples_split_description
                 + "] is not recognized."
             )
 
@@ -588,7 +588,7 @@ class Scenario:
         dict_results["test_data_samples_count"] = len(self.dataset.x_test)
         dict_results["partners_count"] = self.partners_count
         dict_results["amounts_per_partner"] = self.amounts_per_partner
-        dict_results["samples_split_option"] = self.samples_split_option
+        dict_results["samples_split_description"] = self.samples_split_description
         dict_results["nb_samples_used"] = self.nb_samples_used
         dict_results["final_relative_nb_samples"] = self.final_relative_nb_samples
 

--- a/utils.py
+++ b/utils.py
@@ -62,8 +62,8 @@ def get_scenario_params_list(config):
             if scenario['partners_count'] != len(scenario['amounts_per_partner']):
                 raise Exception("Length of amounts_per_partner does not match number of partners.")
 
-            if isinstance(scenario['samples_split_option'], list) \
-                    and (scenario['partners_count'] != len(scenario['samples_split_option'])):
+            if scenario['samples_split_option'][0] == 'advanced' \
+                    and (scenario['partners_count'] != len(scenario['samples_split_option'][1])):
                 raise Exception("Length of samples_split_option does not match number of partners.")
 
             if 'corrupted_datasets' in params_name:


### PR DESCRIPTION
The way `samples_split_option` worked wasn't very clean, as it could take different types of value depending on being initialized to a basic split approach (`'random'` or `'stratified'`) or to an advanced approach (`[[7, 'specific'], [3, 'shared'], [2, 'shared']]`).

Now it looks better:

- it has to be declared as an array with the first value being the type (`'basic'` or `'advanced'`) and the second value the actual split chosen
- the test in `utils.py` for the scenarios combination is done on the type; same for the test in `main.py` for which data splitting function to call
- --> it makes it clean and easy to add new split approaches and even maybe new **types of approaches**

---

Also as suggested in #168, some cleaning with how local val and test sets are populated and used:

- The creation of local val sets is removed from the `preprocess_scenarios_data()` function
- The unused config parameter `single_partner_test_mode` is removed
- Attributes of object `Partner` for local val and test sets are kept
- Creating these val and test sets is now part of the data split functions. For the moment this is basically a `train_test_split()` on each partner's train set

---

Additionnally:

- add a few comments for readibility
- addresses #126 