### PR TITLE
Unit test in partner.py - cifar10

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -36,7 +36,7 @@ class Dataset:
         self.generate_new_model_for_dataset = generate_new_model_for_dataset
 
     def train_val_split(self):
-        # this could be add in the constructor??
+        """Called once, after Dataset's constructor"""
         if self.x_val != None or self.y_val != None:
             raise Exception
 
@@ -45,7 +45,7 @@ class Dataset:
         )
 
     def preprocess_labels(self):
-        # should be removed
+
         self.y_train = self.preprocess_dataset_labels(self.y_train)
         self.y_val = self.preprocess_dataset_labels(self.y_val)
         self.y_test = self.preprocess_dataset_labels(self.y_test)

--- a/dataset.py
+++ b/dataset.py
@@ -36,13 +36,16 @@ class Dataset:
         self.generate_new_model_for_dataset = generate_new_model_for_dataset
 
     def train_val_split(self):
+        # this could be add in the constructor??
+        if self.x_val != None or self.y_val != None:
+            raise Exception
 
         self.x_train, self.x_val, self.y_train, self.y_val = train_test_split(
             self.x_train, self.y_train, test_size=0.2, random_state=42
         )
 
     def preprocess_labels(self):
-
+        # should be removed
         self.y_train = self.preprocess_dataset_labels(self.y_train)
         self.y_val = self.preprocess_dataset_labels(self.y_val)
         self.y_test = self.preprocess_dataset_labels(self.y_test)

--- a/dataset.py
+++ b/dataset.py
@@ -44,11 +44,6 @@ class Dataset:
             self.x_train, self.y_train, test_size=0.2, random_state=42
         )
 
-    def preprocess_labels(self):
-
-        self.y_train = self.preprocess_dataset_labels(self.y_train)
-        self.y_val = self.preprocess_dataset_labels(self.y_val)
-        self.y_test = self.preprocess_dataset_labels(self.y_test)
 
     def generate_new_model(self):
 

--- a/dataset.py
+++ b/dataset.py
@@ -37,8 +37,8 @@ class Dataset:
 
     def train_val_split(self):
         """Called once, after Dataset's constructor"""
-        if self.x_val != None or self.y_val != None:
-            raise Exception
+        if self.x_val or self.y_val:
+            raise Exception("x_val and y_val should be of NoneType")
 
         self.x_train, self.x_val, self.y_train, self.y_val = train_test_split(
             self.x_train, self.y_train, test_size=0.2, random_state=42

--- a/datasets/dataset_mnist.py
+++ b/datasets/dataset_mnist.py
@@ -10,11 +10,16 @@ from keras.layers import Dense, Flatten
 from keras.layers import Conv2D, MaxPooling2D
 import keras
 
+# Init dataset-specific variables
+img_rows = 28
+img_cols = 28
+input_shape = (img_rows, img_cols, 1)
+num_classes = 10
 
 # Data samples pre-processing method for inputs
-def preprocess_dataset_inputs(x, rows, cols):
+def preprocess_dataset_inputs(x):
 
-    x = x.reshape(x.shape[0], rows, cols, 1)
+    x = x.reshape(x.shape[0], img_rows, img_cols, 1)
     x = x.astype("float32")
     x /= 255
 
@@ -32,15 +37,9 @@ def preprocess_dataset_labels(y):
 # Load data
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
 
-# Init dataset-specific variables
-img_rows = 28
-img_cols = 28
-input_shape = (img_rows, img_cols, 1)
-num_classes = 10
-
 # Pre-process inputs
-x_train = preprocess_dataset_inputs(x_train, img_rows, img_cols)
-x_test = preprocess_dataset_inputs(x_test, img_rows, img_cols)
+x_train = preprocess_dataset_inputs(x_train)
+x_test = preprocess_dataset_inputs(x_test)
 
 
 # Model structure and generation

--- a/partner.py
+++ b/partner.py
@@ -33,13 +33,9 @@ class Partner:
         self.y_val = None
         self.y_test = None
 
-    def get_x_train_len(self):  # useless
+    def get_x_train_len(self):  # not used
         return len(self.x_train)
 
-# bizarre?: corrupt_labels suppose que les labels ne sont
-# qu'un tableau d'entier composé de 0 ou 1
-# Donc pas possible de faire autre chose que du categorical-CE
-# Rendre Agnostic du model/dataset!
 
     def corrupt_labels(self):
         if type(self.y_train) != np.ndarray:

--- a/partner.py
+++ b/partner.py
@@ -33,9 +33,6 @@ class Partner:
         self.y_val = None
         self.y_test = None
 
-    def get_x_train_len(self):  # not used
-        return len(self.x_train)
-
 
     def corrupt_labels(self):
         if type(self.y_train) != np.ndarray:

--- a/scenario.py
+++ b/scenario.py
@@ -269,10 +269,10 @@ class Scenario:
         self.contributivity_list.append(contributivity)
 
     def instantiate_scenario_partners(self):
-        """Create the partners_list - should be []"""
+        """Create the partners_list - self.partners_list should be []"""
 
         if self.partners_list != []:
-            raise Exception
+            raise Exception("self.partners_list should be []")
 
         self.partners_list = [Partner(i) for i in range(self.partners_count)]
 
@@ -412,8 +412,8 @@ class Scenario:
     def split_data(self, is_logging_enabled=True):
         """Populates the partners with their train and test data (not pre-processed)"""
 
-        # self.partners_list wasn't change since the initializati
-        assert all([type(self.partners_list[i].x_train) == None for i in range(len(self.partners_list))])
+        # self.partners_list wasn't change since the initialization
+        assert all([not type(self.partners_list[i].x_train) for i in range(len(self.partners_list))]), "Error: partners_list.x_train (for all partners) shouldn't be modified between it's initialization and the call to split_data"
 
         # Fetch parameters of scenario
         x_train = self.dataset.x_train

--- a/scenario.py
+++ b/scenario.py
@@ -259,6 +259,10 @@ class Scenario:
         self.contributivity_list.append(contributivity)
 
     def instantiate_scenario_partners(self):
+        """Create the partners_list - should be []"""
+
+        if self.partners_list != []:
+            raise Exception
 
         self.partners_list = [Partner(i) for i in range(self.partners_count)]
 
@@ -397,6 +401,9 @@ class Scenario:
 
     def split_data(self, is_logging_enabled=True):
         """Populates the partners with their train and test data (not pre-processed)"""
+
+        # self.partners_list wasn't change since the initializati
+        assert all([type(self.partners_list[i].x_train) == None for i in range(len(self.partners_list))])
 
         # Fetch parameters of scenario
         x_train = self.dataset.x_train

--- a/tests.py
+++ b/tests.py
@@ -17,25 +17,33 @@ from datasets import dataset_mnist as data_mn
 from partner import Partner
 from dataset import Dataset
 from scenario import Scenario
-from multi_partner_learning import MultiPartnerLearning
 from pathlib import Path
 from contributivity import Contributivity
+from multi_partner_learning import MultiPartnerLearning
+import multi_partner_learning
 
 
-@pytest.fixture(scope="class", params=["cifar10","mnist"])
-def create_partner(request):
+@pytest.fixture(scope='class', params=['cifar10', 'mnist'])
+def iterate_over_dataset_name(request):
+    yield request.param
+
+
+@pytest.fixture(scope='class')
+def create_Partner(request, iterate_over_dataset_name):
     """Instantiate partner object"""
     part = Partner(partner_id=0)
-    if request.param == "cifar10":
+    dataset_name = iterate_over_dataset_name
+
+    if dataset_name == "cifar10":
         (x_train, y_train), (x_test, y_test) = cifar10.load_data()
         part.y_train = data_cf.preprocess_dataset_labels(y_train)
-    if request.param == "mnist":
+    if dataset_name == "mnist":
         (x_train, y_train), (x_test, y_test) = mnist.load_data()
         part.y_train = data_mn.preprocess_dataset_labels(y_train)
     yield part
 
 
-class Test_partner:
+class Test_Partner:
 
 
     def test_corrupt_labels_type(self):
@@ -45,10 +53,10 @@ class Test_partner:
             part.corrupt_labels()
 
 
-    def test_corrupt_labels_type_elem(self, create_partner):
+    def test_corrupt_labels_type_elem(self, create_Partner):
         """corrupt_labels raise TypeError if partner.y_train isn't float32"""
         with pytest.raises(TypeError):
-            part = create_partner
+            part = create_Partner
             part.y_train = part.y_train.astype("float64")
             part.corrupt_labels(part)
 
@@ -60,25 +68,25 @@ class Test_partner:
             part.shuffle_labels(part)
 
 
-    def test_shuffle_labels_type_elem(self, create_partner):
+    def test_shuffle_labels_type_elem(self, create_Partner):
         """shuffle_labels raise TypeError if partner.y_train isn't float32"""
         with pytest.raises(TypeError):
-            part = create_partner
+            part = create_Partner
             part.y_train = part.y_train.astype("float64")
             part.shuffle_labels(part)
 
 
-@pytest.fixture(scope="class", params=["cifar10","mnist"])
-def create_Dataset(request):
+@pytest.fixture(scope="class")
+def create_Dataset(request, iterate_over_dataset_name):
     """"""
-    name = request.param
-    if name == "cifar10":
+    dataset_name = iterate_over_dataset_name
+    if dataset_name == "cifar10":
         (x_train, y_train), (x_test, y_test) = cifar10.load_data()
         input_shape = data_cf.input_shape
         num_classes = data_cf.num_classes
         preprocess_dataset_labels = data_cf.preprocess_dataset_labels
         generate_new_model_for_dataset = data_cf.generate_new_model_for_dataset
-    if name == "mnist":
+    if dataset_name == "mnist":
         (x_train, y_train), (x_test, y_test) = mnist.load_data()
         input_shape = data_mn.input_shape
         num_classes = data_mn.num_classes
@@ -86,7 +94,7 @@ def create_Dataset(request):
         generate_new_model_for_dataset = data_mn.generate_new_model_for_dataset
 
     dataset = Dataset(
-            dataset_name=name,
+            dataset_name=dataset_name,
             x_train=x_train,
             x_test=x_test,
             y_train=y_train,
@@ -105,13 +113,19 @@ class Test_Dataset:
         assert create_Dataset.name in {"cifar10","mnist"}
 
 
+    def test_train_val_split(self, create_Dataset):
+        """train_val_split is used once, just after Dataset being instantiated - this is written to prevent its call from another place"""
+        data = create_Dataset
+        data.x_val = data.x_train[::]
+        with pytest.raises(Exception):
+            data.train_val_split()
 
-@pytest.fixture
-def create_partner_list(create_partner):
-    yield [create_partner] * 3
+@pytest.fixture(scope='class')
+def create_partner_list(create_Partner):
+    yield [create_Partner] * 3
 
 
-@pytest.fixture
+@pytest.fixture(scope='class')
 def create_MultiPartnerLearning(create_Dataset, create_partner_list):
     data = create_Dataset
     part_list = create_partner_list
@@ -124,8 +138,9 @@ def create_MultiPartnerLearning(create_Dataset, create_partner_list):
             aggregation_weighting="uniform",
             is_early_stopping=True,
             is_save_data=False,
-            save_folder="",
+            save_folder=""
             )
+
     yield mpl
 
 
@@ -133,10 +148,10 @@ def test_mpl(create_MultiPartnerLearning):
     assert type(create_MultiPartnerLearning) == MultiPartnerLearning
 
 
-@pytest.fixture(params=["cifar10", "mnist"])
-def create_scenario(request, create_MultiPartnerLearning, create_Dataset, create_partner_list):
-    dataset_name = request.param
-    params = {"dataset_name": dataset_name, "partners_count":3, "amounts_per_partner": [0.2, 0.5, 0.3], "samples_split_option": ["basic","random"], "multi_partner_learning_aproach":"fedavg", "aggregation_weighting": "uniform", "methods": ["Shapley values", "Independent scores"], "gradient_updates_per_pass_count": 5}
+@pytest.fixture(scope='class')
+def create_Scenario(iterate_over_dataset_name, create_partner_list):
+    dataset_name = iterate_over_dataset_name
+    params = {"dataset_name": dataset_name, "partners_count": 3, "amounts_per_partner": [0.2, 0.5, 0.3], "samples_split_option": ["basic","random"], "multi_partner_learning_aproach":"fedavg", "aggregation_weighting": "uniform", "methods": ["Shapley values", "Independent scores"], "gradient_updates_per_pass_count": 5}
 
     full_experiment_name = "unit-test-pytest"
     experiment_path = Path.cwd() / "experiments" / full_experiment_name
@@ -148,17 +163,41 @@ def create_scenario(request, create_MultiPartnerLearning, create_Dataset, create
             n_repeat=1
             )
 
-    scenar.mpl = create_MultiPartnerLearning
-    scenar.dataset
+    scenar.partners_list = create_partner_list
+
+    scenar.mpl = multi_partner_learning.init_multi_partner_learning_from_scenario(scenario=scenar, is_save_data=True)
+
 
     yield scenar
 
 class Test_Scenario:
 
-    def test_scenar(self, create_scenario):
-        assert type(create_scenario) == Scenario
+    def test_scenar(self, create_Scenario):
+        assert type(create_Scenario) == Scenario
 
+    class Test_instantiate_scenario_partners:
 
+        def test_raiseException(self, create_Scenario):
+            scenar = create_Scenario
+            with pytest.raises(Exception):
+                scenar.instantiate_scenario_partners()
+
+    class Test_split_data:
+        def test_raiseException(self, create_Scenario):
+            scenar = create_Scenario
+            scenar.partners_list[0].x_train = scenar.dataset.x_train
+
+            with pytest.raises(AssertionError):
+                scenar.split_data()
+
+@pytest.fixture(scope='class')
+def create_Contributivity(create_Scenario):
+    scenar = create_Scenario
+    contri = Contributivity(scenario=scenar)
+    return contri
+
+def test(create_Contributivity):
+    assert type(create_Contributivity) == Contributivity
 
 
 @pytest.fixture(scope="class")

--- a/tests.py
+++ b/tests.py
@@ -1,9 +1,40 @@
-# Pytest doc: https://docs.pytest.org/en/latest/getting-started.html#create-your-first-test
+# -*- coding: utf-8 -*-
+"""
+This enables to parameterize unit tests - the tests are run by Travis each you commit to the github repo
+"""
 
+#########
+#
+# Help on Tests:
+#
+##########
+
+# Some usefull commands:
+#
 # pytest tests.py
 # pytest -k TestDemoClass tests.py
 # pytest -k "test_ok" tests.py
+
+# Start the interactive Python debugger on errors or KeyboardInterrupt.
 # pytest tests.py --pdb
+
+# --collect-only, --co  only collect tests, don't execute them.
+# pytest tests.py --co
+
+# Main documentation:
+# https://docs.pytest.org/en/latest/contents.html
+
+# Gettig Started
+# https://docs.pytest.org/en/latest/getting-started.html#group-multiple-tests-in-a-class
+
+# Parametrize to generate parameters combinations
+# https://docs.pytest.org/en/latest/example/parametrize.html#paramexamples
+
+# Fixture to initialize test functions
+#https://docs.pytest.org/en/latest/fixture.html
+
+# Test architecture
+#https://docs.pytest.org/en/latest/goodpractices.html#test-discovery
 
 import utils
 import yaml
@@ -160,6 +191,13 @@ def create_Contributivity(create_Scenario):
     contri = Contributivity(scenario=scenar)
 
     yield contri
+
+
+######
+#
+# Tests modules with Objects
+#
+#####
 
 
 class Test_Partner:

--- a/tests.py
+++ b/tests.py
@@ -247,60 +247,72 @@ class Test_Contributivity:
 ####
 
 @pytest.fixture(scope='class')
-def create_cifar10_x_train():
+def create_cifar10_x():
     (x_train, y_train), (x_test, y_test) = cifar10.load_data()
     x_train = data_cf.preprocess_dataset_inputs(x_train)
-    return x_train
+    x_test = data_cf.preprocess_dataset_inputs(x_test)
+    return x_train, x_test
 
 
 @pytest.fixture(scope='class')
-def create_mnist_x_train():
+def create_mnist_x():
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
     x_train = data_mn.preprocess_dataset_inputs(x_train)
-    return x_train
+    x_test = data_mn.preprocess_dataset_inputs(x_test)
+    return x_train, x_test
 
 
 class Test_dataset_cifar10:
 
-    def test_preprocess_dataset_inputs_type(self, create_cifar10_x_train):
-        """x_train type should be float32"""
-        assert create_cifar10_x_train.dtype == "float32"
+    def test_preprocess_dataset_inputs_type(self, create_cifar10_x):
+        """x_train and x_test type should be float32"""
+        x_train, x_test = create_cifar10_x
+        assert x_train.dtype == "float32"
+        assert x_test.dtype == "float32"
 
-
-    def test_preprocess_dataset_inputs_activation(self, create_cifar10_x_train):
-        """x_train activation should be >=0 and <=1"""
-        x_train = create_cifar10_x_train
+    def test_preprocess_dataset_inputs_activation(self, create_cifar10_x):
+        """x_train and x_test activation should be >=0 and <=1"""
+        x_train, x_test = create_cifar10_x
         greater_than_0 = not False in np.greater_equal(x_train, 0)
         lower_than_1 = not True in np.greater(x_train, 1)
         assert (greater_than_0 and lower_than_1)
 
+        greater_than_0 = not False in np.greater_equal(x_test, 0)
+        lower_than_1 = not True in np.greater(x_test, 1)
+        assert (greater_than_0 and lower_than_1)
 
-    def test_inputs_shape(self, create_cifar10_x_train):
-        """the shape of the elements of x_train is input_shape"""
-        x_train = create_cifar10_x_train
+    def test_inputs_shape(self, create_cifar10_x):
+        """the shape of the elements of x_train and x_test should be equal to input_shape"""
+        x_train, x_test = create_cifar10_x
         assert x_train.shape[1:] == data_cf.input_shape
+        assert x_test.shape[1:] == data_cf.input_shape
 
 
 class Test_dataset_mnist:
 
-    def test_preprocess_dataset_inputs_type(self, create_mnist_x_train):
-        """x_train type should be float32"""
-        assert create_mnist_x_train.dtype == "float32"
+    def test_preprocess_dataset_inputs_type(self, create_mnist_x):
+        """x_train and x_test type should be float32"""
+        x_train, x_test = create_mnist_x
+        assert x_train.dtype == "float32"
+        assert x_test.dtype == "float32"
 
-
-    def test_preprocess_dataset_inputs_activation(self, create_mnist_x_train):
-        """x_train activation should be >=0 and <=1"""
-        x_train = create_mnist_x_train
+    def test_preprocess_dataset_inputs_activation(self, create_mnist_x):
+        """x_train and x_test activation should be >=0 and <=1"""
+        x_train, x_test = create_mnist_x
         greater_than_0 = not False in np.greater_equal(x_train, 0)
         lower_than_1 = not True in np.greater(x_train, 1)
         assert (greater_than_0 and lower_than_1)
 
+        greater_than_0 = not False in np.greater_equal(x_test, 0)
+        lower_than_1 = not True in np.greater(x_test, 1)
+        assert (greater_than_0 and lower_than_1)
 
-    def test_inputs_shape(self, create_mnist_x_train):
-        """the shape of the elements of x_train is input_shape"""
-        x_train = create_mnist_x_train
+
+    def test_inputs_shape(self, create_mnist_x):
+        """the shape of the elements of x_train and x_test should be equal to input_shape"""
+        x_train, x_test = create_mnist_x
         assert x_train.shape[1:] == data_mn.input_shape
-
+        assert x_test.shape[1:] == data_mn.input_shape
 
 class TestDemoClass:
 

--- a/tests.py
+++ b/tests.py
@@ -31,10 +31,10 @@ This enables to parameterize unit tests - the tests are run by Travis each you c
 # https://docs.pytest.org/en/latest/example/parametrize.html#paramexamples
 
 # Fixture to initialize test functions
-#https://docs.pytest.org/en/latest/fixture.html
+# https://docs.pytest.org/en/latest/fixture.html
 
 # Test architecture
-#https://docs.pytest.org/en/latest/goodpractices.html#test-discovery
+# https://docs.pytest.org/en/latest/goodpractices.html#test-discovery
 
 import utils
 import yaml


### PR DESCRIPTION
Add unit tests for the 2 modules `partner.py` and `datasets/dataset_cifar10.py`

This could be used as an example to create new tests when adding a feature to the project
I have first wrote test in the `tests.py` and then implement these constraints in the methods `shuffle_labels` and `corrupt_labels` with ` if ... raise Exception`
These `Exception` are then caught by `with pytest.raises(Exception):`

If we plan to add lots of tests, we could consider creating 1 test module for each module to keep it easy to read.

I need to make these tests more automatic. To test all the functions of the projects, we could create a script that will generate a list of scenario, from the datasets and federated learning approaches currenty supported. This list would be used as arguments in `tests.py` to test more complex functions such as `split_data` (Functions that need `scenario` `mpl` `dataset` objects as arguments)