### PR TITLE
removed typo from root folder

### DIFF
--- a/notebooks/mpl_with_losses.ipynb
+++ b/notebooks/mpl_with_losses.ipynb
@@ -15,7 +15,7 @@
     "from pathlib import Path\n",
     "import pickle\n",
     "\n",
-    "root_folder = exp_path = Path().absolute()..parent / \"experiments\" \n",
+    "root_folder = Path().absolute().parent / \"experiments\" \n",
     "\n",
     "# Get latest generated folder\n",
     "subfolder_list = [f for f in root_folder.iterdir()]\n",


### PR DESCRIPTION
#### Removed typo 
```
root_folder = exp_path = Path().absolute()..parent / "experiments" 
```
#### changed to
```
root_folder = Path().absolute().parent / "experiments" 
```