### PR TITLE
fix numpy version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 librosa==0.8.0
 Keras==2.3.1
 matplotlib==3.1.3
-numpy==1.19.0
+numpy==1.18.5
 scipy==1.4.1
 scikit-learn==0.22.1
 pandas==1.0.5

--- a/mplc/requirements.txt
+++ b/mplc/requirements.txt
@@ -1,7 +1,7 @@
 librosa==0.8.0
 Keras==2.3.1
 matplotlib==3.1.3
-numpy==1.19.0
+numpy==1.18.5
 scipy==1.4.1
 scikit-learn==0.22.1
 pandas==1.0.5


### PR DESCRIPTION
Before we had this error on travis:
`ERROR: tensorflow 2.2.1 has requirement numpy<1.19.0,>=1.16.0, but you'll have numpy 1.19.0 which is incompatible.
`

I don't know how travis managed to make it work, however I had to downgrade numpy on my machine to make it work.
This is a known issue in tensorflow that tensorflow is not compatible with the latest numpy version --> https://github.com/tensorflow/models/issues/9200