### PR TITLE
New mpl method : gradients fusion

### DIFF
--- a/mplc/mpl_utils.py
+++ b/mplc/mpl_utils.py
@@ -101,6 +101,19 @@ class Aggregator(ABC):
 
         return new_weights
 
+    def aggregate_gradients(self):
+        """Aggregate gradients obtained by the backward propagation on the partner's models. """
+        gradients_per_layer = list(zip(*[partner.gradients for partner in self.mpl.partners_list]))
+        fusionned_gradients = list()
+
+        for gradients in gradients_per_layer:
+            avg_gradients_for_layer = np.average(
+                np.array(gradients), axis=0, weights=self.aggregation_weights
+            )
+            fusionned_gradients.append(list(avg_gradients_for_layer))
+
+        return fusionned_gradients
+
 
 class UniformAggregator(Aggregator):
     def __init__(self, mpl):
@@ -134,3 +147,4 @@ AGGREGATORS = {
     "data-volume": DataVolumeAggregator,
     "local-score": ScoresAggregator
 }
+

--- a/mplc/mpl_utils.py
+++ b/mplc/mpl_utils.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from tensorflow import reduce_mean, convert_to_tensor
 
 
 class History:
@@ -105,11 +106,9 @@ class Aggregator(ABC):
         """Aggregate gradients obtained by the backward propagation on the partner's models. """
         gradients_per_layer = list(zip(*[partner.gradients for partner in self.mpl.partners_list]))
         fusionned_gradients = list()
-
+        agg_w_tf = convert_to_tensor(self.aggregation_weights)
         for gradients in gradients_per_layer:
-            avg_gradients_for_layer = np.average(
-                np.array(gradients), axis=0, weights=self.aggregation_weights
-            )
+            avg_gradients_for_layer = reduce_mean(gradients * agg_w_tf, axis=1)
             fusionned_gradients.append(list(avg_gradients_for_layer))
 
         return fusionned_gradients
@@ -139,6 +138,10 @@ class ScoresAggregator(Aggregator):
     def aggregate_model_weights(self):
         self.prepare_aggregation_weights()
         super(ScoresAggregator, self).aggregate_model_weights()
+
+    def aggregate_gradients(self):
+        self.prepare_aggregation_weights()
+        super(ScoresAggregator, self).aggregate_gradients()
 
 
 # Supported aggregation weights approaches

--- a/mplc/multi_partner_learning.py
+++ b/mplc/multi_partner_learning.py
@@ -570,9 +570,9 @@ class GradientFusion(MultiPartnerLearning):
             # Backward pass
             partner.gradients = tape.gradient(loss_value, partner_model.trainable_weights)
 
-            val_history = partner_model.evaluate(self.val_data[0], self.val_data[1])
+            val_history = partner_model.evaluate(self.val_data[0], self.val_data[1], verbose=False)
             history = partner_model.evaluate(partner.minibatched_x_train[self.minibatch_index],
-                                             partner.minibatched_y_train[self.minibatch_index])
+                                             partner.minibatched_y_train[self.minibatch_index], verbose=False)
             history = {
                 "loss": [history[0]],
                 'accuracy': [history[1]],

--- a/notebooks/tutorials/Tutorial-1_Run_your_first_scenario.ipynb
+++ b/notebooks/tutorials/Tutorial-1_Run_your_first_scenario.ipynb
@@ -35,7 +35,10 @@
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
-    "id": "FdlQm3XvBiOM"
+    "id": "FdlQm3XvBiOM",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### Training parameters \n",
@@ -63,7 +66,10 @@
     },
     "colab_type": "code",
     "id": "iyMTIyinBiOM",
-    "outputId": "a6676f6b-50d7-4f3d-98e7-688799895e3f"
+    "outputId": "a6676f6b-50d7-4f3d-98e7-688799895e3f",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -98,7 +104,10 @@
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
-    "id": "rVLFZNorddPk"
+    "id": "rVLFZNorddPk",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## 5 - Run your scenario\n",
@@ -118,7 +127,10 @@
     },
     "colab_type": "code",
     "id": "5HA_xIvsddPl",
-    "outputId": "ea66feef-c405-4808-8c0e-82cbe043c348"
+    "outputId": "ea66feef-c405-4808-8c0e-82cbe043c348",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -401,7 +413,10 @@
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
-    "id": "MeWcWlC5ddPn"
+    "id": "MeWcWlC5ddPn",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## 6 - Explore the results\n",
@@ -419,7 +434,10 @@
     },
     "colab_type": "code",
     "id": "X67YaGm3ddPn",
-    "outputId": "b4f5fe49-64f8-4ddb-f6a4-12a48672c508"
+    "outputId": "b4f5fe49-64f8-4ddb-f6a4-12a48672c508",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -534,7 +552,10 @@
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
-    "id": "XW_EH1fxddPp"
+    "id": "XW_EH1fxddPp",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     " First, our federated model score (computed on the global test set)"
@@ -550,7 +571,10 @@
     },
     "colab_type": "code",
     "id": "hUBKGXfXddPp",
-    "outputId": "0bf25f09-9a27-4097-c9f2-ddb84766e21a"
+    "outputId": "0bf25f09-9a27-4097-c9f2-ddb84766e21a",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [
     {
@@ -569,7 +593,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Let's see how our loss behaves (here the loss is computed on the global validation set)"
    ]
@@ -577,7 +605,11 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -611,7 +643,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "One can be interested on the behaviour of the accuracy score of each partner through the epochs. \n",
     "These information are stored in the history.history dictionnary. The structure of the dictionnary is the following : score\\[partner_id]\\[metric_key][epoch_index, minibatch_index\\]\n",
@@ -652,7 +688,11 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "history_df = my_scenario.mpl.history.partners_to_dataframe()\n",
@@ -675,7 +715,11 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -798,13 +842,20 @@
     "Nice graphics are always more comfortable than brut dataframe, so let's plot it.\n"
    ],
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    }
   },
   {
    "cell_type": "code",
    "execution_count": 69,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -834,7 +885,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "What about the accuracy ? On the validation dataset."
    ]
@@ -842,7 +897,11 @@
   {
    "cell_type": "code",
    "execution_count": 75,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1015,7 +1074,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "One can denote that the local models are better at start, but after few epochs, the collective model shows better abilities to generalize. "
    ]
@@ -1023,7 +1086,11 @@
   {
    "cell_type": "code",
    "execution_count": 78,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1055,7 +1122,10 @@
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
-    "id": "99jaKK2LddPr"
+    "id": "99jaKK2LddPr",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## 7 - Extract the model \n",
@@ -1069,7 +1139,10 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "id": "9wIdoS_bddPr"
+    "id": "9wIdoS_bddPr",
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -1118,7 +1191,10 @@
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
-    "id": "VheE9NyxddPw"
+    "id": "VheE9NyxddPw",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "# That's it !\n",


### PR DESCRIPTION
Add a new method to do federated learning, where we compute gradients for each partner, we aggregate the gradient, and then we use the fusionned gradient to optimize the main model. 

EDIT:  The interest of aggregate the gradient instead if aggregating the weight is to perform the optimization step with the aggreged gradient, so after the aggregation step, at the opposite of fedavg, which make the optimization step, and then the aggregation step. With standard optimizer such as SGD or batch gradient descente, aggregation and fusion step commute. But with more complexe algorithms (which involve momentum, or adaptative learning rate) like bfgs or adam, the order of these two steps matter. 

EDIT: This version of tensorflow/keras does not allow anymore to use modified gradients for the optimization step. 
see the error >>> 
self.optimizer.apply_gradients(zip(fusion_gradients, model.trainable_weights))
AttributeError: 'Adam' object has no attribute 'apply_gradients'

It is really strange, as it is the implementation suggested by the [documentation](https://keras.io/guides/writing_a_training_loop_from_scratch/)  In order to bypass this problem, I will try to fusion the loss and use the .get_updates() method, on the aggregated loss (it should directly compute the aggregated gradient)

EDIT: I failed to use the get_updates() method, I am pretty sure that we need the apply_gradient function... So I am pausing this work, until keras update.  

Signed-off-by: arthurPignet <arthur.pignet@mines-paristech.fr>