### PR TITLE
Add random and permuted corruption methods

### DIFF
--- a/mplc/partner.py
+++ b/mplc/partner.py
@@ -17,11 +17,11 @@ class Partner:
 
         self.batch_size = constants.DEFAULT_BATCH_SIZE
 
-        self.cluster_count = int
-        self.cluster_split_option = str
+        self.cluster_count: int
+        self.cluster_split_option: str
         self.clusters_list = []
-        self.final_nb_samples = int
-        self.final_nb_samples_p_cluster = int
+        self.final_nb_samples: int
+        self.final_nb_samples_p_cluster: int
 
         self.x_train = None
         self.x_val = None
@@ -80,7 +80,7 @@ class Partner:
         idx = sample(list(range(len(self.y_train))), n)
         # Generate the random matrix to use
         alpha = np.random.random(self.num_labels)
-        self.corruption_matrix = np.random.dirichlet(alpha, 10)
+        self.corruption_matrix = np.random.dirichlet(alpha, self.num_labels)
         # Randomize the labels
         for i in idx:  # TODO vectorize
             temp = np.zeros((self.num_labels,))

--- a/mplc/partner.py
+++ b/mplc/partner.py
@@ -84,7 +84,7 @@ class Partner:
                 f"The proportion of labels to corrupted was {proportion_corrupted} but it must be between 0 and 1."
             )
 
-        # Select the indices where the label will be off-set
+        # Select the indices where the label will be permuted
         n = int(len(self.y_train) * proportion_corrupted)
         idx = sample(list(range(len(self.y_train))), n)
         # Generate the permutation matrix to use

--- a/mplc/partner.py
+++ b/mplc/partner.py
@@ -79,7 +79,7 @@ class Partner:
         n = int(len(self.y_train) * proportion_corrupted)
         idx = sample(list(range(len(self.y_train))), n)
         # Generate the random matrix to use
-        alpha = np.random.random(self.num_labels)
+        alpha = np.ones(self.num_labels)
         self.corruption_matrix = np.random.dirichlet(alpha, self.num_labels)
         # Randomize the labels
         for i in idx:  # TODO vectorize

--- a/mplc/scenario.py
+++ b/mplc/scenario.py
@@ -732,26 +732,24 @@ class Scenario:
             # If a data corruption is configured, apply it
             if self.corrupted_datasets[partner_index] == "corrupted":
                 logger.debug(
-                    f"   ... Corrupting (by offsetting labels) 100.0 \
-                            percent of the data of partner #{partner.id}"
+                    f"   ... Corrupting (by offsetting labels) the whole of partner #{partner.id}"
                 )
                 partner.corrupt_labels(1.0)
             elif self.corrupted_datasets[partner_index] == "shuffled":
                 logger.debug(
-                    f"   ... Corrupting (by shuffling labels) 100.0 \
-                            percent of the data of partner #{partner.id}"
+                    f"   ... Corrupting (by shuffling labels) the whole dataset of partner #{partner.id}"
                 )
                 partner.shuffle_labels(1.0)
             elif self.corrupted_datasets[partner_index] == 'permuted':
                 logger.debug(
-                    f'  ... Corrupting (by permuting the labels ) 100.0 percent of the data of partner #{partner.id}.'
-                    f'Permutation matrix available'
+                    f"  ... Corrupting (by permuting the labels ) the whole dataset of partner #{partner.id}."
+                    f"Permutation matrix available"
                 )
                 partner.permute_labels(1.0)
             elif self.corrupted_datasets[partner_index] == 'random':
                 logger.debug(
-                    f'  ... Corrupting (by randomizing the labels ) 100.0 percent of the data of partner #{partner.id}.'
-                    f'Dirichlet distribution matrix available'
+                    f"  ... Corrupting (by randomizing the labels ) the whole dataset of partner #{partner.id}."
+                    f"Dirichlet distribution matrix available"
                 )
                 partner.random_labels(1.0)
             elif self.corrupted_datasets[partner_index][0] == "corrupted":
@@ -768,16 +766,16 @@ class Scenario:
                 partner.shuffle_labels(self.corrupted_datasets[partner_index][1])
             elif self.corrupted_datasets[partner_index][0] == 'permuted':
                 logger.debug(
-                    f'  ... Corrupting (by permuting the labels ) {self.corrupted_datasets[partner_index][1] * 100} '
-                    f'percent of the data of partner #{partner.id}.'
-                    f'Permutation matrix available'
+                    f"  ... Corrupting (by permuting the labels ) {self.corrupted_datasets[partner_index][1] * 100} "
+                    f"percent of the data of partner #{partner.id}."
+                    f"Permutation matrix available"
                 )
                 partner.permute_labels(self.corrupted_datasets[partner_index][1])
             elif self.corrupted_datasets[partner_index][0] == 'random':
                 logger.debug(
-                    f'  ... Corrupting (by randomizing the labels ) {self.corrupted_datasets[partner_index][1] * 100} '
-                    f'percent of the data of partner #{partner.id}.'
-                    f'Dirichlet distribution matrix available'
+                    f"  ... Corrupting (by randomizing the labels ) {self.corrupted_datasets[partner_index][1] * 100} "
+                    f"percent of the data of partner #{partner.id}."
+                    f"Dirichlet distribution matrix available"
                 )
                 partner.random_labels(self.corrupted_datasets[partner_index][1])
             elif self.corrupted_datasets[partner_index] == "not_corrupted":

--- a/mplc/scenario.py
+++ b/mplc/scenario.py
@@ -733,27 +733,53 @@ class Scenario:
             if self.corrupted_datasets[partner_index] == "corrupted":
                 logger.debug(
                     f"   ... Corrupting (by offsetting labels) 100.0 \
-                    percent of the data of partner #{partner.id}"
+                            percent of the data of partner #{partner.id}"
                 )
                 partner.corrupt_labels(1.0)
             elif self.corrupted_datasets[partner_index] == "shuffled":
                 logger.debug(
                     f"   ... Corrupting (by shuffling labels) 100.0 \
-                    percent of the data of partner #{partner.id}"
+                            percent of the data of partner #{partner.id}"
                 )
                 partner.shuffle_labels(1.0)
+            elif self.corrupted_datasets[partner_index] == 'permuted':
+                logger.debug(
+                    f'  ... Corrupting (by permuting the labels ) 100.0 percent of the data of partner #{partner.id}.'
+                    f'Permutation matrix available'
+                )
+                partner.permute_labels(1.0)
+            elif self.corrupted_datasets[partner_index] == 'random':
+                logger.debug(
+                    f'  ... Corrupting (by randomizing the labels ) 100.0 percent of the data of partner #{partner.id}.'
+                    f'Dirichlet distribution matrix available'
+                )
+                partner.random_labels(1.0)
             elif self.corrupted_datasets[partner_index][0] == "corrupted":
                 logger.debug(
                     f"   ... Corrupting (by offsetting labels) {self.corrupted_datasets[partner_index][1] * 100} \
-                    percent of the data of partner #{partner.id}"
+                            percent of the data of partner #{partner.id}"
                 )
                 partner.corrupt_labels(self.corrupted_datasets[partner_index][1])
             elif self.corrupted_datasets[partner_index][0] == "shuffled":
                 logger.debug(
                     f"   ... Corrupting (by shuffling labels) {self.corrupted_datasets[partner_index][1] * 100} \
-                    percent of the data of partner #{partner.id}"
+                            percent of the data of partner #{partner.id}"
                 )
                 partner.shuffle_labels(self.corrupted_datasets[partner_index][1])
+            elif self.corrupted_datasets[partner_index][0] == 'permuted':
+                logger.debug(
+                    f'  ... Corrupting (by permuting the labels ) {self.corrupted_datasets[partner_index][1] * 100} '
+                    f'percent of the data of partner #{partner.id}.'
+                    f'Permutation matrix available'
+                )
+                partner.permute_labels(self.corrupted_datasets[partner_index][1])
+            elif self.corrupted_datasets[partner_index][0] == 'random':
+                logger.debug(
+                    f'  ... Corrupting (by randomizing the labels ) {self.corrupted_datasets[partner_index][1] * 100} '
+                    f'percent of the data of partner #{partner.id}.'
+                    f'Dirichlet distribution matrix available'
+                )
+                partner.random_labels(self.corrupted_datasets[partner_index][1])
             elif self.corrupted_datasets[partner_index] == "not_corrupted":
                 pass
             else:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -220,11 +220,9 @@ class Test_Partner:
     def test_shuffle_labels(self, create_Partner):
         """partner.y_train should be a numpy.ndarray"""
         partner = create_Partner
-        one_label = np.argmax(partner.y_train[-1])
         partner.corrupt_labels(1.)
         assert partner.y_train[-1].max() == 1
         assert partner.y_train[-1].sum() == 1
-        assert one_label != np.argmax(partner.y_train[-1])
 
 
 class Test_Mpl:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -195,34 +195,39 @@ class Test_Partner:
     def test_corrupt_labels(self, create_Partner):
         """partner.y_train should be a numpy.ndarray"""
         partner = create_Partner
-        one_label = np.argmax(partner.y_train[-1])
         partner.corrupt_labels(1.)
-        assert partner.y_train[-1].max() == 1
-        assert partner.y_train[-1].sum() == 1
-        assert one_label != np.argmax(partner.y_train[-1])
+        assert ((partner.y_train == 0) + (partner.y_train == 1)).all()
+        if partner.y_train.ndim > 1:
+            assert partner.y_train[-1].max() == 1
+            assert partner.y_train[-1].sum() == 1
 
     def test_permute_labels(self, create_Partner):
         """partner.y_train should be a numpy.ndarray"""
         partner = create_Partner
         partner.permute_labels(1.)
-        ones_vect = np.ones(partner.y_train.shape[1])
+        assert ((partner.y_train == 0) + (partner.y_train == 1)).all()
+        ones_vect = np.ones(partner.corruption_matrix.shape[1])
         assert (partner.corruption_matrix.sum(axis=1) == ones_vect).all()
         assert (partner.corruption_matrix.sum(axis=0) == ones_vect.T).all()
 
     def test_random_labels(self, create_Partner):
         partner = create_Partner
         partner.random_labels(1.)
-        assert partner.y_train[-1].max() == 1
-        assert partner.y_train[-1].sum() == 1
-        ones_vect = np.ones(partner.y_train.shape[1])
+        assert ((partner.y_train == 0) + (partner.y_train == 1)).all()
+        if partner.y_train.ndim > 1:
+            assert partner.y_train[-1].max() == 1
+            assert partner.y_train[-1].sum() == 1
+        ones_vect = np.ones(partner.corruption_matrix.shape[1])
         assert (partner.corruption_matrix.sum(axis=1).round(1) == ones_vect).all()
 
     def test_shuffle_labels(self, create_Partner):
         """partner.y_train should be a numpy.ndarray"""
         partner = create_Partner
-        partner.corrupt_labels(1.)
-        assert partner.y_train[-1].max() == 1
-        assert partner.y_train[-1].sum() == 1
+        partner.shuffle_labels(1.)
+        assert ((partner.y_train == 0) + (partner.y_train == 1)).all()
+        if partner.y_train.ndim > 1:
+            assert partner.y_train[-1].max() == 1
+            assert partner.y_train[-1].sum() == 1
 
 
 class Test_Mpl:


### PR DESCRIPTION
Add two corruption methods.

Permuted :  a permutation matrix is randomly generated, stored, and used to flip the labels
Random : a Dirichlet distribution is generated for each label, stored in a stochastic matrix, and used to flip the labels. 


Signed-off-by: arthurPignet <arthur.pignet@mines-paristech.fr>