### PR TITLE
Change Cifar10's model optimizer

### DIFF
--- a/mplc/dataset.py
+++ b/mplc/dataset.py
@@ -21,7 +21,7 @@ from keras.layers import Dense, Dropout
 from keras.layers import Embedding, Conv1D, MaxPooling1D, Flatten
 from keras.losses import categorical_crossentropy
 from keras.models import Sequential
-from keras.optimizers import RMSprop
+from keras.optimizers import Adam
 from keras.preprocessing import sequence
 from keras.utils import to_categorical
 from librosa import load as wav_load
@@ -189,10 +189,8 @@ class Cifar10(Dataset):
         model.add(Dense(self.num_classes))
         model.add(Activation('softmax'))
 
-        # initiate RMSprop optimizer
-        opt = RMSprop(learning_rate=0.0001, decay=1e-6)
-
-        # Let's train the model using RMSprop
+        # initiate Adam optimizer
+        opt = Adam(learning_rate=0.001, decay=1e-5)
         model.compile(loss='categorical_crossentropy',
                       optimizer=opt,
                       metrics=['accuracy'])


### PR DESCRIPTION
The RMSprop optimizer can be changed to adam with a different learning rate. It greatly improves the training performance, as shown below. 

![image](https://user-images.githubusercontent.com/49653631/100435541-5d1bc880-309e-11eb-8f41-907e904c10b5.png)
![image](https://user-images.githubusercontent.com/49653631/100435510-50977000-309e-11eb-8c43-c2fa1e2af34a.png)
![image](https://user-images.githubusercontent.com/49653631/100436011-0cf13600-309f-11eb-8c5a-72c6f2956ddc.png)


However, even if I tried a few learning rates and decay values, these are propably not the perfect hyperparameters, do not hesitate to suggest another setup. 



Signed-off-by: arthurPignet <arthur.pignet@mines-paristech.fr>