### PR TITLE
Switch local or global val/test set

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Alternatively, you can also use the `main.py` provided in the repository, with a
        amounts_per_partner:
          - [0.4, 0.3, 0.3]
        samples_split_option:
-         - ['basic', 'random']
+         - 'random'
          - ['advanced', [[7, 'shared'], [6, 'shared'], [2, 'specific']]]
        multi_partner_learning_approach:
          - 'fedavg'

--- a/config_quick_debug.yml
+++ b/config_quick_debug.yml
@@ -2,24 +2,25 @@ experiment_name: debug_config
 n_repeats: 1
 scenario_params_list:
  - dataset_name:
-    'mnist':
-      - 'random_initialization'
+     'mnist':
+       - 'random_initialization'
    partners_count:
-    - 3
+     - 3
    amounts_per_partner:
-    - [0.2, 0.5, 0.3]
+     - [ 0.2, 0.5, 0.3 ]
    samples_split_option:
-     - ['basic', 'random']
-     - ['basic', 'stratified']
-     - ['advanced', [[4, 'shared'], [6, 'shared'], [4, 'specific']]]
+     - 'random'
+     - 'stratified'
+     - [ 'advanced', [ ][ 4, 'shared' ], [ 6, 'shared' ], [ 4, 'specific' ] ] ]
+
    multi_partner_learning_approach:
-    - 'fedavg'
+     - 'fedavg'
    aggregation_weighting:
-    - 'uniform'
+     - 'uniform'
    contributivity_methods:
      - [ "Federated SBS constant", "Federated SBS linear", "Federated SBS quadratic", "Shapley values", "Independent scores", "TMCS" ]
    gradient_updates_per_pass_count:
-    - 5
+     - 5
    is_quick_demo:
     - True
    dataset_proportion:

--- a/mplc/contributivity.py
+++ b/mplc/contributivity.py
@@ -996,7 +996,7 @@ class Contributivity:
             partner_values = np.exp(w) / (1.0 + np.exp(w))
             previous_loss = loss
 
-        mpl.eval_and_log_final_model__test_perf()
+        mpl.eval_and_log_final_model_test_perf()
         mpl.save_data()
         end = timer()
         mpl.learning_computation_time = end - start

--- a/mplc/corruption.py
+++ b/mplc/corruption.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+"""
+This enables to corrupt partner's datasets.
+"""
+
 from abc import ABC, abstractmethod
 
 import numpy as np

--- a/mplc/corruption.py
+++ b/mplc/corruption.py
@@ -241,7 +241,7 @@ class Duplication(Corruption):
         return self._corrupted_test_idx
 
     def set_duplicated_partner(self, partner_list):
-        if not self.duplicated_partner_id:
+        if self.duplicated_partner_id is None:  # We cannot use the `if not self.dupl... ` because if not 0 return True
             raise Exception('Missing the Partner-to-duplicate\'s id.')
         self.duplicated_partner = [partner for partner in partner_list if partner.id == self.duplicated_partner_id][0]
 

--- a/mplc/corruption.py
+++ b/mplc/corruption.py
@@ -249,7 +249,7 @@ class Duplication(Corruption):
         if not self.duplicated_partner:
             raise Exception('Missing the Partner to duplicate')
         self.generate_matrix()
-        idx = self.corrupted_index
+        idx = self.corrupted_train_index
         if self.duplicated_partner.y_train.ndim == 1:
             self.duplicated_partner.y_train = to_categorical(self.duplicated_partner.y_train.reshape(-1, 1))
             one_label = True

--- a/mplc/dataset.py
+++ b/mplc/dataset.py
@@ -13,6 +13,7 @@ from urllib.request import urlretrieve
 
 import numpy as np
 import pandas as pd
+from joblib import dump, load
 from librosa import load as wav_load
 from librosa.feature import mfcc
 from loguru import logger
@@ -58,7 +59,10 @@ class Dataset(ABC):
 
         self.proportion = 1
         self.shorten_dataset_proportion(proportion)
-        self.train_val_split_global()
+
+        self.x_train, self.x_val, self.y_train, self.y_val = train_test_split(self.x_train,
+                                                                              self.y_train,
+                                                                              test_size=val_proportion)
 
     def __str__(self):
         return f'{self.name} dataset'

--- a/mplc/dataset.py
+++ b/mplc/dataset.py
@@ -61,7 +61,8 @@ class Dataset(ABC):
 
         self.x_train, self.x_val, self.y_train, self.y_val = train_test_split(self.x_train,
                                                                               self.y_train,
-                                                                              test_size=val_proportion)
+                                                                              test_size=val_proportion,
+                                                                              stratify=self.y_train)
 
     def __str__(self):
         return f'{self.name} dataset'
@@ -524,7 +525,7 @@ class Esc50(Dataset):
             logger.info('ESC-50 dataset found')
 
         esc50_df = pd.read_csv(folder / 'esc50.csv')
-        train, test = train_test_split(esc50_df, test_size=0.1)
+        train, test = train_test_split(esc50_df, test_size=0.1, stratify=esc50_df.target.to_numpy())
         y_train = train.target.to_numpy()
         y_test = test.target.to_numpy()
         x_train = (wav_load((folder / 'audio' / file_name).resolve(), sr=None)

--- a/mplc/dataset.py
+++ b/mplc/dataset.py
@@ -42,8 +42,8 @@ class Dataset(ABC):
                  y_train,
                  x_test,
                  y_test,
-                 val_proportion=0.1,
-                 proportion=1
+                 proportion=1,
+                 val_proportion=0.1
                  ):
         self.name = dataset_name
 
@@ -96,7 +96,8 @@ class Dataset(ABC):
 
 
 class Cifar10(Dataset):
-    def __init__(self):
+    def __init__(self, proportion=1,
+                 val_proportion=0.1):
         self.input_shape = (32, 32, 3)
         self.num_classes = 10
         x_test, x_train, y_test, y_train = self.load_data()
@@ -107,7 +108,9 @@ class Cifar10(Dataset):
                                       x_train=x_train,
                                       y_train=y_train,
                                       x_test=x_test,
-                                      y_test=y_test)
+                                      y_test=y_test,
+                                      proportion=proportion,
+                                      val_proportion=val_proportion)
 
     def load_data(self):
         attempts = 0
@@ -188,7 +191,8 @@ class Cifar10(Dataset):
 
 
 class Titanic(Dataset):
-    def __init__(self):
+    def __init__(self, proportion=1,
+                 val_proportion=0.1):
         self.num_classes = 2
         self.input_shape = (27,)
         # Load data
@@ -200,7 +204,9 @@ class Titanic(Dataset):
                                       x_train=x_train,
                                       y_train=y_train,
                                       x_test=x_test,
-                                      y_test=y_test
+                                      y_test=y_test,
+                                      proportion=proportion,
+                                      val_proportion=val_proportion
                                       )
 
     # Init dataset-specific functions
@@ -360,7 +366,8 @@ class Titanic(Dataset):
 
 
 class Mnist(Dataset):
-    def __init__(self):
+    def __init__(self, proportion=1,
+                 val_proportion=0.1):
         # Init dataset-specific variables
         self.img_rows = 28
         self.img_cols = 28
@@ -374,7 +381,9 @@ class Mnist(Dataset):
                                     x_train=x_train,
                                     y_train=y_train,
                                     x_test=x_test,
-                                    y_test=y_test
+                                    y_test=y_test,
+                                    proportion=proportion,
+                                    val_proportion=val_proportion
                                     )
 
     def load_data(self):
@@ -445,7 +454,8 @@ class Mnist(Dataset):
 
 
 class Imdb(Dataset):
-    def __init__(self):
+    def __init__(self, proportion=1,
+                 val_proportion=0.1):
         self.num_words = 5000
         self.num_classes = 2
         self.input_shape = (500,)
@@ -457,7 +467,9 @@ class Imdb(Dataset):
                                    x_train=x_train,
                                    y_train=y_train,
                                    x_test=x_test,
-                                   y_test=y_test
+                                   y_test=y_test,
+                                   proportion=proportion,
+                                   val_proportion=val_proportion
                                    )
 
     def load_data(self):
@@ -524,7 +536,8 @@ class Imdb(Dataset):
 
 
 class Esc50(Dataset):
-    def __init__(self):
+    def __init__(self, proportion=1,
+                 val_proportion=0.1):
         # Load data
         self.num_classes = 50
         self.input_shape = (40, 431, 1)
@@ -537,7 +550,9 @@ class Esc50(Dataset):
                                     x_train=x_train,
                                     y_train=y_train,
                                     x_test=x_test,
-                                    y_test=y_test
+                                    y_test=y_test,
+                                    proportion=proportion,
+                                    val_proportion=val_proportion
                                     )
 
     # Init dataset-specific functions

--- a/mplc/dataset.py
+++ b/mplc/dataset.py
@@ -272,7 +272,7 @@ class Titanic(Dataset):
         y = raw_dataset['Survived']
         y = y.to_numpy(dtype='float32')
 
-        x_train, x_test, y_train, y_test = self.train_test_split_global(x, y)
+        x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.1, random_state=42)
 
         return (x_train, y_train), (x_test, y_test)
 

--- a/mplc/dataset.py
+++ b/mplc/dataset.py
@@ -522,6 +522,7 @@ class Imdb(Dataset):
 
         return model
 
+
 class Esc50(Dataset):
     def __init__(self):
         # Load data

--- a/mplc/dataset.py
+++ b/mplc/dataset.py
@@ -598,7 +598,7 @@ class Esc50(Dataset):
             logger.info('ESC-50 dataset found')
 
         esc50_df = pd.read_csv(folder / 'esc50.csv')
-        train, test = self.train_test_split_global(esc50_df)
+        train, test = train_test_split(esc50_df, test_size=0.1)
         y_train = train.target.to_numpy()
         y_test = test.target.to_numpy()
         x_train = (wav_load((folder / 'audio' / file_name).resolve(), sr=None)

--- a/mplc/doc/documentation.md
+++ b/mplc/doc/documentation.md
@@ -243,8 +243,10 @@ There are 2 ways to select a dataset. You can either choose a pre-implemented da
         Configuration:  
         - `nb of clusters (int)`: the given partner will receive data samples from that many different clusters (clusters of data samples per labels/classes)
         - `'shared'` or `'specific'`:
-         - `'shared'`: all partners with option `'shared'` receive data samples picked from clusters they all share data samples from
-         - `'specific'`: each partner with option `'specific'` receives data samples picked from cluster(s) it is the only one to receive from
+         - `'shared'`: all partners with option `'shared'` receive data samples picked
+                       from clusters they all share data samples from
+         - `'specific'`: each partner with option `'specific'` receives data samples picked 
+                         from cluster(s) it is the only one to receive from
 
   Example: `samples_split_option='advanced', samples_split_configuration=[[7, 'shared'], [6, 'shared'], [2, 'specific'], [1, 'specific']]]`
 

--- a/mplc/doc/documentation.md
+++ b/mplc/doc/documentation.md
@@ -232,19 +232,21 @@ There are 2 ways to select a dataset. You can either choose a pre-implemented da
   Example: `amounts_per_partner=[0.3, 0.3, 0.1, 0.3]`
 
 <a id="sample_split_option"></a>
-- `samples_split_option`: `['basic', 'random']` (default), `['basic', 'stratified']` or `['advanced', [[nb of clusters (int), 'shared' or 'specific']]]`   
+- `samples_split_option`: Used to set the strategy of samples data split. You can either instantiate a Splitter before passing it to Scenario, as in the below example, or you can pass it by its string identifier. In the latter case, the default parameters for the Splitter selected will be used.
   How the original dataset data samples are split among partners:
-  
-    - `'basic'` approaches:
-      - `'random'`: the dataset is shuffled and partners receive data samples selected randomly
-      - `'stratified'`: the dataset is stratified per class and each partner receives certain classes only (note: depending on the `amounts_per_partner` specified, there might be small overlaps of classes)
-    - `'advanced'` approach `[[nb of clusters (int), 'shared' or 'specific']]`: in certain cases it might be interesting to split the dataset among partners in a more elaborate way. For that we consider the data samples from the initial dataset as split in clusters per data labels. The advanced split is configured by indicating, for each partner in sequence, the following 2 elements:
-      - `nb of clusters (int)`: the given partner will receive data samples from that many different clusters (clusters of data samples per labels/classes)
-      - `'shared'` or `'specific'`:
-        - `'shared'`: all partners with option `'shared'` receive data samples picked from clusters they all share data samples from
-        - `'specific'`: each partner with option `'specific'` receives data samples picked from cluster(s) it is the only one to receive from
+    - `RandomSplitter`: the dataset is shuffled and partners receive data samples selected randomly
+        String identifier: `'random'`
+    - `StratifiedSplitter`: the dataset is stratified per class and each partner receives certain classes only (note: depending on the `amounts_per_partner` specified, there might be small overlaps of classes)
+        String identifier: `'stratified'``[[nb of clusters (int), 'shared' or 'specific']]`
+    - `'AdvancedSplitter'`: in certain cases it might be interesting to split the dataset among partners in a more elaborate way. For that we consider the data samples from the initial dataset as split in clusters per data labels. The advanced split is configured by indicating, for each partner in sequence, the following 2 elements: `[[nb of clusters (int), 'shared' or 'specific']]`. Practically, you can either instantiate your `AdvancedSplitter` object, and pass this list `[[nb of clusters (int), 'shared' or 'specific']]` to the keyword argument `description`, or use the string identifier and pass the list `[[nb of clusters (int), 'shared' or 'specific']]` to the scenario via the keyword argument `samples_split_configuration`.
+        String identifier:`'advanced'`.
+        Configuration:  
+        - `nb of clusters (int)`: the given partner will receive data samples from that many different clusters (clusters of data samples per labels/classes)
+        - `'shared'` or `'specific'`:
+         - `'shared'`: all partners with option `'shared'` receive data samples picked from clusters they all share data samples from
+         - `'specific'`: each partner with option `'specific'` receives data samples picked from cluster(s) it is the only one to receive from
 
-  Example: `samples_split_option=['advanced', [[7, 'shared'], [6, 'shared'], [2, 'specific'], [1, 'specific']]]`
+  Example: `samples_split_option='advanced', samples_split_configuration=[[7, 'shared'], [6, 'shared'], [2, 'specific'], [1, 'specific']]]`
 
 ![Example of the advanced split option](../../img/advanced_split_example.png)
 

--- a/mplc/partner.py
+++ b/mplc/partner.py
@@ -29,13 +29,13 @@ class Partner:
         self.final_nb_samples: int
         self.final_nb_samples_p_cluster: int
 
-        self.x_train = None
-        self.x_val = None
-        self.x_test = None
+        self.x_train = []
+        self.x_val = []
+        self.x_test = []
 
-        self.y_train = None
-        self.y_val = None
-        self.y_test = None
+        self.y_train = []
+        self.y_val = []
+        self.y_test = []
 
     @property
     def num_labels(self):

--- a/mplc/partner.py
+++ b/mplc/partner.py
@@ -50,7 +50,10 @@ class Partner:
 
     @property
     def labels(self):
-        return list(set(self.y_train))
+        if self.y_train.ndim == 1:
+            return np.unique(self.y_train)
+        else:
+            return np.unique(np.argmax(self.y_train, axis=1))
 
     def corrupt(self):
         # Check if the labels are encoded into categorical. If not, convert them

--- a/mplc/partner.py
+++ b/mplc/partner.py
@@ -26,7 +26,6 @@ class Partner:
         self.cluster_count: int
         self.cluster_split_option: str
         self.clusters_list = []
-        self.final_nb_samples: int
         self.final_nb_samples_p_cluster: int
 
         self.x_train = []
@@ -44,6 +43,14 @@ class Partner:
     @property
     def data_volume(self):
         return len(self.y_train)
+
+    @property
+    def final_nb_samples(self):
+        return len(self.y_train)
+
+    @property
+    def labels(self):
+        return list(set(self.y_train))
 
     def corrupt(self):
         # Check if the labels are encoded into categorical. If not, convert them

--- a/mplc/scenario.py
+++ b/mplc/scenario.py
@@ -378,8 +378,6 @@ class Scenario:
     def copy(self, **kwargs):
         params = self.__dict__.copy()
         for key in ['partners_list',
-                    'samples_split_type',
-                    'samples_split_description',
                     'mpl',
                     '_multi_partner_learning_approach',
                     '_aggregation',
@@ -387,7 +385,8 @@ class Scenario:
                     'contributivity_list',
                     'scenario_name',
                     'short_scenario_name',
-                    'save_folder']:
+                    'save_folder',
+                    'splitter']:
             del params[key]
         if 'is_quick_demo' in kwargs and kwargs['is_quick_demo'] != self.is_quick_demo:
             raise ValueError("Attribute 'is_quick_demo' cannot be modified between copies.")
@@ -395,6 +394,8 @@ class Scenario:
             params['save_path'] = self.save_folder.parents[0]
         else:
             params['save_path'] = None
+        params['samples_split_option'] = self.splitter.copy()
+
         params.update(kwargs)
 
         return Scenario(**params)

--- a/mplc/scenario.py
+++ b/mplc/scenario.py
@@ -57,31 +57,12 @@ class Scenario:
         :param dataset: dataset.Dataset object. Use it if you want to use your own dataset, otherwise use dataset_name.
         :param dataset_name: str. 'mnist', 'cifar10', 'esc50' and 'titanic' are currently supported (default: mnist)
         :param dataset_proportion: float (default: 1)
-        :param samples_split_option: ['basic', 'random'] (default),
-                                     ['basic', 'stratified']
-                                     or ['advanced', [[nb of clusters (int), 'shared' or 'specific']]].
-        :param corruption_parameters: list of map. Enables to artificially corrupt the data of one or several partners.
-                                   The size of the list must be equal to the number of partners.
-                                   Items of the list must be mapping. The possible keys, values are the following:
-                                    'corruption_method': 'not_corrupted' (default),
-                                                         'duplication',
-                                                         'permutation',
-                                                         'permutation-circular',
-                                                         'random',
-                                                         'random-uniform',
-                                                         'redundancy'
-                                    Indicating the corruption method to use to corrupt the partner's data
-                                    'proportion_corrupted': 1. (default), float between 0. and 1. indicating the
-                                                                          proportion of partner's data to corrupt
-                                    'duplicated_partner_id': Partner_id used by the duplicate corruption method.
-                                                          If not provided, a random partner amongst those
-                                                          with enough data will be selected
-
-                                   Example with 3 partners.
-                                   [{}, {'corruption_method':'permutation'},
-                                    {'corruption_method':'duplication',
-                                    'proportion_corrupted': 0.4,
-                                    'duplicated_partner_id': 0}]
+        :param samples_split_option: Splitter object, or its string identifier (for instance 'random', or 'stratified')
+                                     Define the strategy to use to split the data samples between the partners.
+                                     Default, RandomSplitter.
+        :param corruption_parameters: list of Corruption object, or its string identifier, one ofr each partner.
+                                      Enable to artificially corrupt partner's data.
+                                      For instance: [Permutation(proportion=0.2), 'random', 'not-corrupted']
         :param init_model_from: None (default) or path
         :param multi_partner_learning_approach: 'fedavg' (default), 'seq-pure', 'seq-with-final-agg' or 'seqavg'
                                                 Define the multi-partner learning approach

--- a/mplc/scenario.py
+++ b/mplc/scenario.py
@@ -837,6 +837,7 @@ class Scenario:
 
         # Configure the desired data distribution scenario
         # In the 'stratified' scenario we sort by labels
+
         if self.samples_split_description == "stratified":
             # Sort by labels
             train_idx = y_train.argsort()

--- a/mplc/scenario.py
+++ b/mplc/scenario.py
@@ -176,14 +176,14 @@ class Scenario:
         self.amounts_per_partner = amounts_per_partner
 
         #  To configure how validation set and test set will be organized.
-        if test_set in ['local', 'global', 'both']:
+        if test_set in ['local', 'global']:
             self.test_set = test_set
         else:
-            raise ValueError(f'Test set can be \'local\', \'global\' or \'both\', not {test_set}')
-        if test_set in ['local', 'global', 'both']:
+            raise ValueError(f'Test set can be \'local\' or \'global\' not {test_set}')
+        if val_set in ['local', 'global']:
             self.val_set = val_set
         else:
-            raise ValueError(f'Validation set can be \'local\', \'global\' or \'both\', not {val_set}')
+            raise ValueError(f'Validation set can be \'local\' or \'global\' not {val_set}')
 
         # To configure if data samples are split between partners randomly or in a stratified way...
         # ... so that they cover distinct areas of the samples space

--- a/mplc/scenario.py
+++ b/mplc/scenario.py
@@ -509,7 +509,7 @@ class Scenario:
         dict_results["test_data_samples_count"] = len(self.dataset.x_test)
         dict_results["partners_count"] = self.partners_count
         dict_results["dataset_fraction_per_partner"] = self.amounts_per_partner
-        dict_results["samples_split_description"] = self.samples_split_description
+        dict_results["samples_split_option"] = str(self.splitter)
         dict_results["nb_samples_used"] = self.nb_samples_used
         dict_results["final_relative_nb_samples"] = self.final_relative_nb_samples
 

--- a/mplc/scenario.py
+++ b/mplc/scenario.py
@@ -609,7 +609,7 @@ class Scenario:
                 idx_in_full_valset = np.where(y_val == label)
                 x_val_for_cluster[label] = self.dataset.x_val[idx_in_full_valset]
                 y_val_for_cluster[label] = self.dataset.y_val[idx_in_full_valset]
-                nb_samples_per_cluster[label] = len(y_val_for_cluster[label])
+                nb_samples_per_cluster_val[label] = len(y_val_for_cluster[label])
 
             # We need to enforce the relative data amounts configured.
             # It might not be possible to distribute all data samples, depending on...
@@ -621,7 +621,7 @@ class Scenario:
             resize_factor_specific_val = 1
             for p in partners_with_specific_clusters:
                 nb_available_samples = sum(
-                    [nb_samples_per_cluster[cl] for cl in p.clusters_list]
+                    [nb_samples_per_cluster_val[cl] for cl in p.clusters_list]
                 )
                 nb_samples_requested = int(amounts_per_partner[p.id] * len(y_val))
                 ratio = nb_available_samples / nb_samples_requested
@@ -645,7 +645,7 @@ class Scenario:
             for cl in nb_samples_needed_per_cluster:
                 resize_factor_shared_val = min(
                     resize_factor_shared_val,
-                    nb_samples_per_cluster[cl] / nb_samples_needed_per_cluster[cl],
+                    nb_samples_per_cluster_val[cl] / nb_samples_needed_per_cluster[cl],
                 )
 
             # Compute the final resize factor
@@ -701,7 +701,7 @@ class Scenario:
                 idx_in_full_testset = np.where(y_test == label)
                 x_test_for_cluster[label] = self.dataset.x_test[idx_in_full_testset]
                 y_test_for_cluster[label] = self.dataset.y_test[idx_in_full_testset]
-                nb_samples_per_cluster[label] = len(y_test_for_cluster[label])
+                nb_samples_per_cluster_test[label] = len(y_test_for_cluster[label])
 
             # We need to enforce the relative data amounts configured.
             # It might not be possible to distribute all data samples, depending on...
@@ -713,7 +713,7 @@ class Scenario:
             resize_factor_specific_test = 1
             for p in partners_with_specific_clusters:
                 nb_available_samples = sum(
-                    [nb_samples_per_cluster[cl] for cl in p.clusters_list]
+                    [nb_samples_per_cluster_test[cl] for cl in p.clusters_list]
                 )
                 nb_samples_requested = int(amounts_per_partner[p.id] * len(y_test))
                 ratio = nb_available_samples / nb_samples_requested
@@ -737,7 +737,7 @@ class Scenario:
             for cl in nb_samples_needed_per_cluster:
                 resize_factor_shared_test = min(
                     resize_factor_shared_test,
-                    nb_samples_per_cluster[cl] / nb_samples_needed_per_cluster[cl],
+                    nb_samples_per_cluster_test[cl] / nb_samples_needed_per_cluster[cl],
                 )
 
             # Compute the final resize factor

--- a/mplc/scenario.py
+++ b/mplc/scenario.py
@@ -186,7 +186,7 @@ class Scenario:
         else:
             raise ValueError(f'Test set can be \'local\', \'global\' or \'both\', not {test_set}')
         if test_set in ['local', 'global', 'both']:
-            self.val_set = self.val_set
+            self.val_set = val_set
         else:
             raise ValueError(f'Validation set can be \'local\', \'global\' or \'both\', not {val_set}')
 
@@ -887,7 +887,7 @@ class Scenario:
             p.clusters_list = list(set(y_train[train_idx]))
 
         if self.val_set == 'local':
-            for partner_idx, val_idx in val_idx_idx_list:
+            for partner_idx, val_idx in enumerate(val_idx_idx_list):
                 p = self.partners_list[partner_idx]
 
                 # Finalize selection of val data
@@ -896,7 +896,7 @@ class Scenario:
                 p.y_val = self.dataset.y_val[val_idx]
 
         if self.test_set == 'local':
-            for partner_idx, test_idx in test_idx_idx_list:
+            for partner_idx, test_idx in enumerate(test_idx_idx_list):
                 p = self.partners_list[partner_idx]
 
                 # Finalize selection of test data

--- a/mplc/splitter.py
+++ b/mplc/splitter.py
@@ -79,6 +79,15 @@ class Splitter(ABC):
     def _generate_subset(self, x, y):
         return [(x, y) for _ in self.partners_list]
 
+    def __copy__(self):
+        kwargs = self.__dict__.copy()
+        del kwargs['dataset']
+        del kwargs['partners_list']
+        return self.__class__(**kwargs)
+
+    def copy(self):
+        return self.__copy__()
+
 
 class RandomSplitter(Splitter):
     name = 'Random samples split'

--- a/mplc/splitter.py
+++ b/mplc/splitter.py
@@ -130,6 +130,9 @@ class AdvancedSplitter(Splitter):
         self.num_clusters, self.specific_shared = list(zip(*configuration))
         super().__init__(amounts_per_partner, **kwargs)
 
+    def __str__(self):
+        return self.name + str(list(zip(self.num_clusters, self.specific_shared)))
+
     def _generate_subset(self, x, y):
         lb = LabelEncoder()
         y_str = lb.fit_transform([str(label) for label in y])
@@ -159,12 +162,12 @@ class AdvancedSplitter(Splitter):
             shared_clusters_count = 0
         assert (
                 specific_clusters_count + shared_clusters_count <= nb_diff_labels
-        ), "Error: data samples from the \
-            initial dataset are split in clusters per data labels - Incompatibility between the split arguments \
-            and the dataset provided \
-            - Example: ['advanced', [[7, 'shared'], [6, 'shared'], [2, 'specific'], [1, 'specific']]] \
-            means 7 shared clusters and 2 + 1 = 3 specific clusters ==> This scenario can't work with a dataset with \
-            less than 10 labels"
+        ), f"Error: data samples from the initial dataset are split in clusters per data labels - " \
+           f"Incompatibility between the split arguments and the dataset provided: " \
+           f"{specific_clusters_count + shared_clusters_count}, {nb_diff_labels} " \
+           f"- Example: ['advanced', [[7, 'shared'], [6, 'shared'], [2, 'specific'], [1, 'specific']]] means 7" \
+           f" shared clusters and 2 + 1 = 3 specific clusters " \
+           f"==> This scenario can't work with a dataset with less than 10 labels"
 
         x_for_cluster, y_for_cluster, nb_samples_per_cluster = {}, {}, {}
         for label in labels:

--- a/mplc/splitter.py
+++ b/mplc/splitter.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""
+This enables to split the original dataset between the partners.
+"""
+import operator
+from abc import ABC, abstractmethod
+
+import numpy as np
+from sklearn.preprocessing import LabelEncoder
+
+
+class Splitter(ABC):
+    def __init__(self, dataset, partners_list, amounts_per_partner, val_set='global', test_set='global'):
+
+        self.amounts_per_partner = amounts_per_partner
+        self.test_set = test_set
+        self.val_set = val_set
+        self.dataset = dataset
+        self.partners_list = partners_list
+
+        # Check the percentages of samples per partner and control its coherence
+        assert (
+                len(self.amounts_per_partner) == self.partners_count
+        ), "Error: in the provided config file, \
+                    amounts_per_partner list should have a size equals to partners_count"
+        assert (
+                np.sum(self.amounts_per_partner) == 1
+        ), "Error: in the provided config file, \
+                    amounts_per_partner argument: the sum of the proportions you provided isn't equal to 1"
+
+    @property
+    def partners_count(self):
+        return len(self.partners_list)
+
+    def split(self):
+        self._split_train()
+        if self.val_set == 'local':
+            self._split_val()
+        if self.test_set == 'local':
+            self._split_test()
+
+    def _split_train(self):
+        subsets = self._generate_subset(self.dataset.x_train, self.dataset.y_train)
+        for idx, p in enumerate(self.partners_list):
+            p.x_train, p.y_train = subsets[idx]
+
+    def _split_val(self):
+        subsets = self._generate_subset(self.dataset.x_val, self.dataset.y_val)
+        for idx, p in enumerate(self.partners_list):
+            p.x_val, p.y_val = subsets[idx]
+
+    def _split_test(self):
+        subsets = self._generate_subset(self.dataset.x_test, self.dataset.y_test)
+        for idx, p in enumerate(self.partners_list):
+            p.x_test, p.y_test = subsets[idx]
+
+    @abstractmethod
+    def _generate_subset(self, x, y):
+        return [(x, y) for _ in self.partners_list]
+
+
+class RandomSplitter(Splitter):
+    def _generate_subset(self, x, y):
+        if self.partners_count == 1:
+            return [(x, y)]
+        else:
+            y = LabelEncoder().fit_transform([str(label) for label in y])
+            splitting_indices = (np.cumsum(self.amounts_per_partner)[:-1] * len(y)).astype(int)
+            idxs = np.arange(len(y))
+            np.random.shuffle(idxs)
+            idx_list = np.split(idxs, splitting_indices)
+            res = []
+            for slice_idx in idx_list:
+                res.append((x[slice_idx], y[slice_idx]))
+            return res
+
+
+class StratifiedSplitter(Splitter):
+    def _generate_subset(self, x, y):
+        if self.partners_count == 1:
+            return [(x, y)]
+        else:
+            y = LabelEncoder().fit_transform([str(label) for label in y])
+            splitting_indices = (np.cumsum(self.amounts_per_partner)[:-1] * len(y)).astype(int)
+            idxs = y.argsort()
+            idx_list = np.split(idxs, splitting_indices)
+            res = []
+            for slice_idx in idx_list:
+                res.append((x[slice_idx], y[slice_idx]))
+            return res
+
+
+class AdvancedSplitter(Splitter):
+    def __init__(self, dataset, partners_list, amounts_per_partner, samples_split_description):
+        self.num_clusters, self.specific_shared = list(zip(*samples_split_description))
+        super().__init__(dataset, partners_list, amounts_per_partner)
+
+    def _generate_subset(self, x, y):
+        lb = LabelEncoder()
+        y = lb.fit_transform([str(label) for label in y])
+        nb_diff_labels = len(lb.classes_)
+
+        for p_id, p in enumerate(self.partners_list):
+            p.cluster_count_param = self.specific_shared[p_id]
+            p.cluster_split_option = self.num_clusters[p_id]
+
+        partners_with_specific_clusters = [p for p, option in zip(self.partners_list, self.specific_shared) if
+                                           option == 'specific']
+        partners_with_specific_clusters.sort(key=operator.attrgetter("cluster_count"), reverse=True)
+        partners_with_shared_clusters = [p for p, option in zip(self.partners_list, self.specific_shared) if
+                                         option == 'shared']
+        partners_with_shared_clusters.sort(key=operator.attrgetter("cluster_count"), reverse=True)
+
+        specific_clusters_count = sum(
+            [p.cluster_count for p in partners_with_specific_clusters]
+        )
+        if partners_with_shared_clusters:
+            shared_clusters_count = max(
+                [p.cluster_count for p in partners_with_shared_clusters]
+            )
+        else:
+            shared_clusters_count = 0
+        assert (
+                specific_clusters_count + shared_clusters_count <= nb_diff_labels
+        ), "Error: data samples from the \
+            initial dataset are split in clusters per data labels - Incompatibility between the split arguments \
+            and the dataset provided \
+            - Example: ['advanced', [[7, 'shared'], [6, 'shared'], [2, 'specific'], [1, 'specific']]] \
+            means 7 shared clusters and 2 + 1 = 3 specific clusters ==> This scenario can't work with a dataset with \
+            less than 10 labels"
+
+        x_for_cluster, y_for_cluster, nb_samples_per_cluster = {}, {}, {}
+        for label in lb.classes_:
+            idx_in_full_set = np.where(y == label)
+            x_for_cluster[label] = x[idx_in_full_set]
+            y_for_cluster[label] = y[idx_in_full_set]
+            nb_samples_per_cluster[label] = len(y_for_cluster[label])

--- a/mplc/splitter.py
+++ b/mplc/splitter.py
@@ -3,41 +3,57 @@
 This enables to split the original dataset between the partners.
 """
 import operator
+import random
 from abc import ABC, abstractmethod
 
 import numpy as np
+from loguru import logger
 from sklearn.preprocessing import LabelEncoder
 
 
 class Splitter(ABC):
-    def __init__(self, dataset, partners_list, amounts_per_partner, val_set='global', test_set='global'):
+    def __init__(self, amounts_per_partner, val_set='global', test_set='global'):
 
         self.amounts_per_partner = amounts_per_partner
         self.test_set = test_set
         self.val_set = val_set
-        self.dataset = dataset
-        self.partners_list = partners_list
+
+        self.dataset = None
+        self.partners_list = None
 
         # Check the percentages of samples per partner and control its coherence
-        assert (
-                len(self.amounts_per_partner) == self.partners_count
-        ), "Error: in the provided config file, \
-                    amounts_per_partner list should have a size equals to partners_count"
-        assert (
-                np.sum(self.amounts_per_partner) == 1
-        ), "Error: in the provided config file, \
-                    amounts_per_partner argument: the sum of the proportions you provided isn't equal to 1"
+        if np.sum(self.amounts_per_partner) != 1:
+            raise ValueError("The sum of the amount per partners you provided isn't equal to 1")
 
     @property
     def partners_count(self):
         return len(self.partners_list)
 
-    def split(self):
+    def split(self, partners_list, dataset):
+        self.dataset = dataset
+        self.partners_list = partners_list
+        if len(self.amounts_per_partner) != self.partners_count:
+            raise AttributeError(f"The amounts_per_partner list should have a size ({len(self.amounts_per_partner)}) "
+                                 f"equals to partners_count ({self.partners_count})")
+
+        logger.info("### Splitting data among partners:")
+        logger.info("Train data split:")
         self._split_train()
+
         if self.val_set == 'local':
+            logger.info("Validation data split:")
             self._split_val()
+
         if self.test_set == 'local':
+            logger.info("Test data split:")
             self._split_test()
+
+        for partner in self.partners_list:
+            logger.info(
+                f"   Partner #{partner.id}: "
+                f"{partner.final_nb_samples} samples "
+                f"with labels {partner.labels}"
+            )
 
     def _split_train(self):
         subsets = self._generate_subset(self.dataset.x_train, self.dataset.y_train)
@@ -91,32 +107,34 @@ class StratifiedSplitter(Splitter):
 
 
 class AdvancedSplitter(Splitter):
-    def __init__(self, dataset, partners_list, amounts_per_partner, samples_split_description):
+    def __init__(self, amounts_per_partner, samples_split_description, **kwargs):
         self.num_clusters, self.specific_shared = list(zip(*samples_split_description))
-        super().__init__(dataset, partners_list, amounts_per_partner)
+        super().__init__(amounts_per_partner, **kwargs)
 
     def _generate_subset(self, x, y):
         lb = LabelEncoder()
         y = lb.fit_transform([str(label) for label in y])
+        labels = list(set(y))
+        np.random.shuffle(labels)
         nb_diff_labels = len(lb.classes_)
 
         for p_id, p in enumerate(self.partners_list):
-            p.cluster_count_param = self.specific_shared[p_id]
-            p.cluster_split_option = self.num_clusters[p_id]
+            p.cluster_count_param = self.num_clusters[p_id]
+            p.cluster_split_option = self.specific_shared[p_id]
 
         partners_with_specific_clusters = [p for p, option in zip(self.partners_list, self.specific_shared) if
                                            option == 'specific']
-        partners_with_specific_clusters.sort(key=operator.attrgetter("cluster_count"), reverse=True)
+        partners_with_specific_clusters.sort(key=operator.attrgetter("cluster_count_param"), reverse=True)
         partners_with_shared_clusters = [p for p, option in zip(self.partners_list, self.specific_shared) if
                                          option == 'shared']
-        partners_with_shared_clusters.sort(key=operator.attrgetter("cluster_count"), reverse=True)
+        partners_with_shared_clusters.sort(key=operator.attrgetter("cluster_count_param"), reverse=True)
 
         specific_clusters_count = sum(
-            [p.cluster_count for p in partners_with_specific_clusters]
+            [p.cluster_count_param for p in partners_with_specific_clusters]
         )
         if partners_with_shared_clusters:
             shared_clusters_count = max(
-                [p.cluster_count for p in partners_with_shared_clusters]
+                [p.cluster_count_param for p in partners_with_shared_clusters]
             )
         else:
             shared_clusters_count = 0
@@ -130,8 +148,101 @@ class AdvancedSplitter(Splitter):
             less than 10 labels"
 
         x_for_cluster, y_for_cluster, nb_samples_per_cluster = {}, {}, {}
-        for label in lb.classes_:
+        for label in labels:
             idx_in_full_set = np.where(y == label)
             x_for_cluster[label] = x[idx_in_full_set]
             y_for_cluster[label] = y[idx_in_full_set]
             nb_samples_per_cluster[label] = len(y_for_cluster[label])
+
+        # For each partner compose the list of clusters from which they will draw data samples
+        index = 0
+        for p in partners_with_specific_clusters:
+            p.clusters_list = labels[index: index + p.cluster_count_param]
+            index += p.cluster_count_param
+
+        shared_clusters = labels[index: index + shared_clusters_count]
+        for p in partners_with_shared_clusters:
+            p.clusters_list = random.sample(shared_clusters, k=p.cluster_count_param)
+
+        # We need to enforce the relative data amounts configured.
+        # It might not be possible to distribute all data samples, depending on...
+        # ... the coherence of the relative data amounts and the split option.
+        # We will compute a resize factor to determine the total nb of samples to be distributed per partner
+
+        # For partners getting data samples from specific clusters...
+        # ... compare the nb of available samples vs. the nb of samples initially configured
+        resize_factor_specific = 1
+        for p in partners_with_specific_clusters:
+            nb_available_samples = sum(
+                [nb_samples_per_cluster[cl] for cl in p.clusters_list]
+            )
+            nb_samples_requested = int(self.amounts_per_partner[p.id] * len(y))
+            ratio = nb_available_samples / nb_samples_requested
+            resize_factor_specific = min(resize_factor_specific, ratio)
+
+        # For each partner getting data samples from shared clusters:
+        # ... compute the nb of samples initially configured and resize it,
+        # ... then sum per cluster how many samples are needed.
+        # Then, find if a cluster is requested more samples than it has, and if yes by which factor
+        resize_factor_shared = 1
+        nb_samples_needed_per_cluster = dict.fromkeys(shared_clusters, 0)
+        for p in partners_with_shared_clusters:
+            initial_amount_resized = int(
+                self.amounts_per_partner[p.id] * len(y) * resize_factor_specific
+            )
+            initial_amount_resized_per_cluster = int(
+                initial_amount_resized / p.cluster_count_param
+            )
+            for cl in p.clusters_list:
+                nb_samples_needed_per_cluster[cl] += initial_amount_resized_per_cluster
+        for cl in nb_samples_needed_per_cluster:
+            resize_factor_shared = min(
+                resize_factor_shared,
+                nb_samples_per_cluster[cl] / nb_samples_needed_per_cluster[cl],
+            )
+
+        # Compute the final resize factor
+        final_resize_factor = resize_factor_specific * resize_factor_shared
+
+        # Size correctly each partner's subset. For each partner:
+        final_nb_samples_per_partner = [int(amount * len(y) * final_resize_factor)
+                                        for amount in self.amounts_per_partner]
+        final_nb_samples_p_cluster = [int(nb_samples / p.cluster_count_param)
+                                      for nb_samples, p in zip(final_nb_samples_per_partner, self.partners_list)]
+
+        total_nb_samples = sum(final_nb_samples_per_partner)
+        relative_nb_sample = [nb / total_nb_samples for nb in final_nb_samples_per_partner]
+
+        # Partners receive their subsets
+        shared_clusters_index = dict.fromkeys(shared_clusters, 0)
+        res = []
+        for p in self.partners_list:
+
+            list_arrays_x, list_arrays_y = [], []
+
+            if p in partners_with_shared_clusters:
+                for cl in p.clusters_list:
+                    idx = shared_clusters_index[cl]
+                    list_arrays_x.append(
+                        x_for_cluster[cl][idx: idx + final_nb_samples_p_cluster[p.id]]
+                    )
+                    list_arrays_y.append(
+                        y_for_cluster[cl][idx: idx + final_nb_samples_p_cluster[p.id]]
+                    )
+                    shared_clusters_index[cl] += final_nb_samples_p_cluster[p.id]
+            elif p in partners_with_specific_clusters:
+                for cl in p.clusters_list:
+                    list_arrays_x.append(
+                        x_for_cluster[cl][: final_nb_samples_p_cluster[p.id]]
+                    )
+                    list_arrays_y.append(
+                        y_for_cluster[cl][: final_nb_samples_p_cluster[p.id]]
+                    )
+            res.append((np.concatenate(list_arrays_x), np.concatenate(list_arrays_y)))
+
+        logger.info(
+            f"Partners' relative number of samples: {[round(nb, 2) for nb in relative_nb_sample]} "
+            f"(versus initially configured: {self.amounts_per_partner})"
+        )
+
+        return res

--- a/mplc/splitter.py
+++ b/mplc/splitter.py
@@ -14,7 +14,7 @@ from sklearn.preprocessing import LabelEncoder
 class Splitter(ABC):
     name = 'Abstract Splitter'
 
-    def __init__(self, amounts_per_partner, val_set='global', test_set='global'):
+    def __init__(self, amounts_per_partner, val_set='global', test_set='global', **kwargs):
 
         self.amounts_per_partner = amounts_per_partner
         self.test_set = test_set
@@ -117,8 +117,8 @@ class StratifiedSplitter(Splitter):
 class AdvancedSplitter(Splitter):
     name = 'Advanced samples split'
 
-    def __init__(self, amounts_per_partner, samples_split_description, **kwargs):
-        self.num_clusters, self.specific_shared = list(zip(*samples_split_description))
+    def __init__(self, amounts_per_partner, configuration, **kwargs):
+        self.num_clusters, self.specific_shared = list(zip(*configuration))
         super().__init__(amounts_per_partner, **kwargs)
 
     def _generate_subset(self, x, y):

--- a/mplc/utils.py
+++ b/mplc/utils.py
@@ -76,9 +76,12 @@ def get_scenario_params_list(config):
             scenario = dict(zip(params_name, el))
             if scenario['partners_count'] != len(scenario['amounts_per_partner']):
                 raise Exception("Length of amounts_per_partner does not match number of partners.")
-            if scenario['samples_split_option'][0] == 'advanced' \
-                    and (scenario['partners_count'] != len(scenario['samples_split_option'][1])):
-                raise Exception("Length of samples_split_option does not match number of partners.")
+            if scenario['samples_split_option'][0] == 'advanced':
+                if scenario['partners_count'] != len(scenario['samples_split_option'][1]):
+                    raise Exception("Length of samples_split_option does not match number of partners.")
+                else:
+                    scenario['samples_split_configuration'] = scenario['samples_split_option'][1]
+                    scenario['samples_split_option'] = scenario['samples_split_option'][0]
             if 'corruption_parameters' in params_name:
                 if scenario['partners_count'] != len(scenario['corruption_parameters']):
                     raise Exception("Length of corruption_parameters does not match number of partners.")

--- a/tests/config_end_to_end_test_contrib.yml
+++ b/tests/config_end_to_end_test_contrib.yml
@@ -8,8 +8,8 @@ scenario_params_list:
      - 2
    amounts_per_partner: 
      - [0.1, 0.9]
-   samples_split_option: 
-     - ['basic', 'random']
+   samples_split_option:
+     - 'random'
    multi_partner_learning_approach:
      - 'fedavg'
    contributivity_methods:

--- a/tests/config_end_to_end_test_mnist.yml
+++ b/tests/config_end_to_end_test_mnist.yml
@@ -8,8 +8,8 @@ scenario_params_list:
      - 3
    amounts_per_partner: 
      - [0.4, 0.3, 0.3]
-   samples_split_option: 
-     - ['basic', 'random']
+   samples_split_option:
+     - 'random'
    multi_partner_learning_approach:
      - 'fedavg'
      - 'seq-pure'

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -290,15 +290,6 @@ class Test_Dataset:
         with pytest.raises(Exception):
             data.train_val_split_global()
 
-    def test_local_split(self, create_all_datasets):
-        data = create_all_datasets
-        x_train, x_val, y_train, y_val = data.train_val_split_local(data.x_train, data.y_train)
-        assert len(x_train) == len(y_train)
-        assert len(x_val) == len(y_val)
-        x_train, x_test, y_train, y_test = data.train_val_split_local(data.x_train, data.y_train)
-        assert len(x_train) == len(y_train)
-        assert len(x_test) == len(y_test)
-
     def test_data_shape(self, create_all_datasets):
         data = create_all_datasets
         assert len(data.x_train) == len(data.y_train), "Number of train label is not equal to the number of data"

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -54,6 +54,8 @@ from mplc.mpl_utils import UniformAggregator
 from mplc.multi_partner_learning import FederatedAverageLearning
 from mplc.partner import Partner
 from mplc.scenario import Scenario
+# create_Mpl uses create_Dataset and create_Contributivity uses create_Scenario
+from mplc.splitter import AdvancedSplitter
 
 
 ######
@@ -64,7 +66,6 @@ from mplc.scenario import Scenario
 # to be free to create weird objects, then give them to the test functions.
 ######
 
-# create_Mpl uses create_Dataset and create_Contributivity uses create_Scenario
 
 @pytest.fixture(scope="class", params=(Mnist, Cifar10, Titanic, Imdb, Esc50))
 def create_all_datasets(request):
@@ -99,14 +100,15 @@ def create_Partner(create_all_datasets):
 
 
 @pytest.fixture(scope="class",
-                params=((Mnist, ["basic", "random"], ['not-corrupted'] * 3),
-                        (Mnist, ["basic", "random"],
-                         ['permutation', Redundancy(0.2), Duplication(duplicated_partner_id=0)]),
-                        (Mnist, ["advanced", [[4, "specific"], [6, "shared"], [4, "shared"]]], ['not-corrupted'] * 3),
-                        (Cifar10, ["basic", "random"], ['not-corrupted'] * 3),
-                        (
-                                Cifar10, ["advanced", [[4, "specific"], [6, "shared"], [4, "shared"]]],
-                                ['not-corrupted'] * 3)),
+                params=((Mnist, "random", ['not-corrupted'] * 3),
+                        (Mnist, "random", ['permutation', Redundancy(0.2), Duplication(duplicated_partner_id=0)]),
+                        (Mnist,
+                         AdvancedSplitter([0.3, 0.5, 0.2], [[4, "specific"], [6, "shared"], [4, "shared"]]),
+                         ['not-corrupted'] * 3),
+                        (Cifar10, "random", ['not-corrupted'] * 3),
+                        (Cifar10,
+                         AdvancedSplitter([0.3, 0.5, 0.2], [[4, "specific"], [6, "shared"], [4, "shared"]]),
+                         ['not-corrupted'] * 3)),
                 ids=['Mnist - basic',
                      'Mnist - basic - corrupted',
                      'Mnist - advanced',
@@ -213,7 +215,7 @@ class Test_Scenario:
             scenario.instantiate_scenario_partners()
 
 
-class Test_Corruption:
+class iTest_Corruption:
     def test_permutation_circular(self, create_Partner):
         partner = create_Partner
         partner.corruption = PermutationCircular(partner=partner)
@@ -279,7 +281,7 @@ class Test_Contributivity:
 #
 ######
 
-class Test_Dataset:
+class iTest_Dataset:
 
     def test_train_split_global(self, create_all_datasets):
         """train_val_split is used once, just after Dataset being instantiated

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -215,7 +215,7 @@ class Test_Scenario:
             scenario.instantiate_scenario_partners()
 
 
-class iTest_Corruption:
+class Test_Corruption:
     def test_permutation_circular(self, create_Partner):
         partner = create_Partner
         partner.corruption = PermutationCircular(partner=partner)
@@ -281,7 +281,7 @@ class Test_Contributivity:
 #
 ######
 
-class iTest_Dataset:
+class Test_Dataset:
 
     def test_train_split_global(self, create_all_datasets):
         """train_val_split is used once, just after Dataset being instantiated


### PR DESCRIPTION
add an option on how compute val score and test score. If set to local, the global test/val set will be split between partners exactly like the train set. it will also be corrupted as the train set is. 

Then the val score and test score for global model will be the average of the scores computed on each partners set. 

 closing #287 