### PR TITLE
Release of mplc v0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ with open("mplc/requirements.txt", "r") as fh:
 
 setup(
     name="mplc",
-    version='0.2',
+    version='0.3.0',
     author="SubstraFoundation",
     author_email="contact@substra.org",
-    description="A distributed learning contributivity package",
+    description="A distributed-learning package for the study of contributivity",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/SubstraFoundation/distributed-learning-contributivity",

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
               'distributed learning'],
     license='Apache 2.0',
     install_requires=requirements,
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
We planned to release a new version of mplc on git, pip and conda. 

the release note are shown below, please don't hesitated to comment !

------------------

# MPLC v0.3 Release notes

This release introduces several changes to the library which is now offering more modularity. It is also deployed on [PyPI](https://pypi.org/project/mplc/).

## Features

- Multiple code refactorization: Refacto the multi-partner learning approaches in a more object oriented way. [#255](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/255)
- New `Experiment` object: An object which runs and repeats several scenarios and gathers results to simplify their analysis. [#275](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/275)
- New corruption methods and options: Refacto the corruption in a more object oriented way. Add `random`, `permutation`, `duplication`, `redundancy` ways to corrupt a dataset. [#280](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/280) & [#277](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/277)
- Updated datasets integration: Change module architecture. The datasets are now a subclass of the `Dataset` class. [#262](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/262)
- Updated tutorial notebooks. [#266](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/266)
- Documentation: Update and format documentation. [#264](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/264) & [#294](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/294)
- Add code coverage badge: A new badge on the README, to follow the extension of the test coverage. [#268](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/268)
- More tests added: There is now end-to-end tests for contributivity methods and multi-partner learning approaches. [#304](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/304) &  [#300](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/300)
- Add `FederatedGradient`: New multi-partner learning method. The gradients are aggregated (instead of the weights). Then the optimizer updates the model with the aggregated gradient. [#299](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/299)
- Add S-model: New multi-partner learning method. It adds for each partner a NoiseAdaptative layer, which is supposed to adapt to potential label flip and thus improve the shared model performances, even with corrupted partners. 
[#281](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/281) & [#301](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/301)
- Add local/global option for test and validation datasets. The dataset is split (only once! and in a stratified way) between train/test/validation datasets. If `‘local’`, these test/validation datasets are splitted between partners, in the exact same way than the training one. [#288](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/288)

## Fixes

- Fix bugs in corruption by permutation: A transposition was missing. [#284](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/284)
- Update Cifar10 model optimizer: The learning rate was way too low. We also switched from RMSprop to Adam for the optimizer, as it showed better performances.  [#283](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/283)
- Fix early stopping: Condition for early stopping was not reachable. [#279](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/279)
- Logs: Add epoch number when showing evaluation metrics. [#274](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/274)
- Dependencies updates: Removal of Keras (We now exclusively use the tensorflow's built-in Keras module), upgrade to Tensor Flow v2.4.0, Numpy v1.19.4, Scikit Learn v0.23.2, Pandas v1.1.5. [#290](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/290)
- Switch to Github Actions instead of Travis for Continuous Integration. [#298](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/298)
- Normalize contributivity scores in step-by-step methods. [#295](https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/295)

## Contributors

This release received successful contributions from:

- [bowni](https://github.com/bowni)
- [arthurPignet](https://github.com/arthurPignet)
- [RomainGoussault](https://github.com/RomainGoussault)
- [Thomas-Galtier](https://github.com/Thomas-Galtier)
- [celinejacques](https://github.com/celinejacques)
- [natct10](https://github.com/natct10)
- [jeromechambost](https://github.com/jeromechambost)
- [JustineBoulant](https://github.com/JustineBoulant)
- [Meylina](https://github.com/Meylina)


