### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+black:
+	black .
+
+flake:
+	flake8 --max-line-length=120
+
+tests:
+	pytest -vv tests/ml_perf_end_to_end_tests.py
+	pytest -vv tests/contrib_end_to_end_tests.py
+

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,5 @@ tests:
 	pytest -vv tests/ml_perf_end_to_end_tests.py
 	pytest -vv tests/contrib_end_to_end_tests.py
 
+all: black flake tests
+

--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,11 @@ tests:
 	pytest -vv tests/ml_perf_end_to_end_tests.py
 	pytest -vv tests/contrib_end_to_end_tests.py
 
+tests-ml-perf:
+	pytest -vv tests/ml_perf_end_to_end_tests.py
+
+test-contrib:
+	pytest -vv tests/contrib_end_to_end_tests.py
+
 all: black flake tests
 


### PR DESCRIPTION
You can use `make black`, `make flake`, `make tests`, `make tests-ml-perf` and `make test-contrib`. Please install `make` to test. 
Windows users might use chocolatey package manager: https://chocolatey.org/packages/make.

Started here: https://github.com/SubstraFoundation/distributed-learning-contributivity/pull/319
Fix #312 