### PR TITLE
Testing nightly builds

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
   schedule:
-    - cron: '0 0 * * * '
+    - cron: '0 0 * * * ' # Every day at 00.00
 
 jobs:
   build:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -1,6 +1,9 @@
 name: Build
 
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * * '
 
 jobs:
   build:


### PR DESCRIPTION
As far as I understood, scheduled build can only be activated on the workflow on the default branch, master.
That means that it cannot be executed from a non-default branch, thus quite hard to reproduce (even locally, I tried with [act](https://github.com/nektos/act)).
I propose to merge this lone update, after changing the schedule to a convenient hour, to test it live.

Another PR could be open to segregate heavy tests only for the nightly builds.