### PR TITLE
Federated averaging with local and global optimizations

### DIFF
--- a/mplc/doc/documentation.md
+++ b/mplc/doc/documentation.md
@@ -314,6 +314,20 @@ There are several parameters influencing how the collaborative and distributed l
   - `'seqavg'`: stands for sequential averaging
 
     ![Schema seqavg](../../img/collaborative_rounds_seqavg.png)
+    
+  The previous methods are implemented to be agnostic to the model used. However, some of these methods are also implemented within the tensorflow interface, at a lower level. These implementations are usually faster, especially if you are using a GPU. Unfortunately, those methods are only compatible with tensorflow.keras-based models. The mplc-native dataset `Titanic` cannot be used.
+  
+  Available methods:
+    - `'fast-fedavg'`: equivalent to FedAvg.
+    - `'fast-fedgrads'`: equivalent to FedGrad.
+    - `'fast-fedavg-smodel'`: equivalent to FedAvg, with smodel
+    - `'fast-fedgrad-smodel'`: equivalent to FedGrad with smodel
+    - `'fast-fedgdo'`: Stand for Federated averaging with double optimizers. This method is inspired from Federated gradient, but with modification on the local computation of the gradient.
+    A local optimizer (partner-specific) is used to do several minimization steps (local minibatches) of the local-loss
+    during a global-minibatch. We use the sum of these weighs-updates as the gradient which is sent to the global optimizer.
+    The global optimizer aggregates these gradients, which have been sent by the partners,
+    and performs a optimization step with this aggregated gradient.
+       
 
   Example: `multi_partner_learning_approach='seqavg'`
 

--- a/mplc/multi_partner_learning/__init__.py
+++ b/mplc/multi_partner_learning/__init__.py
@@ -14,7 +14,8 @@ FAST_TF_MPL_APPROACHES = {
     'fast-fedavg': fast_mpl.FastFedAvg,
     'fast-fedgrads': fast_mpl.FastFedGrad,
     'fast-fedavg-smodel': fast_mpl.FastFedAvgSmodel,
-    'fast-fedgrad-smodel': fast_mpl.FastGradSmodel
+    'fast-fedgrad-smodel': fast_mpl.FastGradSmodel,
+    'fast-fedgdo': fast_mpl.FastFedGDO
 }
 
 MULTI_PARTNER_LEARNING_APPROACHES = BASIC_MPL_APPROACHES.copy()

--- a/mplc/multi_partner_learning/fast_mpl.py
+++ b/mplc/multi_partner_learning/fast_mpl.py
@@ -588,9 +588,9 @@ class FastFedGDO(FastFedAvg):
     name = 'FastFedGDO'
 
     def __init__(self, scenario, reset_local_optims=False, global_optimiser=None, **kwargs):
-        super(FastFedGDO, self).__init__(scenario, **kwargs)
         self.global_optimiser = global_optimiser
         self.reset_local_optims = reset_local_optims
+        super(FastFedGDO, self).__init__(scenario, **kwargs)
 
     def init_specific_tf_variable(self):
         # generate tf Variables in which we will store the model weights

--- a/mplc/multi_partner_learning/fast_mpl.py
+++ b/mplc/multi_partner_learning/fast_mpl.py
@@ -602,6 +602,8 @@ class FastFedGDO(FastFedAvg):
         self.partners_optimizers = [self.model.optimizer.from_config(self.model.optimizer.get_config()) for _ in
                                     self.partners_list]
         if self.global_optimiser:
+            # If the global optimizer is specified in the kwargs. If not the global optimizer used is the
+            # default one, same as the local optimizer, and we don't need to re-compile the model
             self.model.compile(optimizer=self.global_optimiser)
 
     def fit(self):

--- a/mplc/multi_partner_learning/fast_mpl.py
+++ b/mplc/multi_partner_learning/fast_mpl.py
@@ -575,3 +575,92 @@ class FastGradSmodel(FastFedGrad):
                 break
 
         self.log_end_training()
+
+
+class FastFedGDO(FastFedAvg):
+    """
+     This method is inspired from Federated gradient, but with modification on the local computation of the gradient.
+    In this version we use a local optimizer (partner-specific) to do several minimization steps of the local-loss
+    during a minibatch. We use the sum of these weighs-updates as the gradient which is sent to the global optimizer.
+    The global optimizer aggregates these gradients-like which have been sent by the partners,
+    and performs a optimization step with this aggregated gradient.
+    """
+    name = 'FastFedGDO'
+
+    def __init__(self, scenario, reset_local_optims=False, **kwargs):
+        super(FastFedGDO, self).__init__(scenario, **kwargs)
+        self.reset_local_optims = reset_local_optims
+
+    def init_specific_tf_variable(self):
+        # generate tf Variables in which we will store the model weights
+        self.model_stateholder = [tf.Variable(initial_value=w.read_value()) for w in self.model.trainable_weights]
+        self.partners_grads = [[tf.Variable(initial_value=w.read_value()) for w in self.model.trainable_weights]
+                               for _ in self.partners_list]
+        self.global_grad = [tf.Variable(initial_value=w.read_value()) for w in self.model.trainable_weights]
+        self.partners_optimizers = [self.model.optimizer.from_config(self.model.optimizer.get_config()) for _ in
+                                    self.partners_list]
+
+    def fit(self):
+        # TF function definition
+        @tf.function
+        def fit_minibatch(model, model_stateholder, partners_minibatches, partners_optimizers, partners_grads,
+                          global_grad, aggregation_weights):
+            for model_w, old_w in zip(model.trainable_weights, model_stateholder):  # store model weights
+                old_w.assign(model_w.read_value())
+
+            for p_id, minibatch in enumerate(partners_minibatches):  # minibatch == (x,y)
+                # minibatch[0] in a tensor of shape=(number of batch, batch size, img).
+                # We cannot iterate on tensors, so we convert this tensor to a list of
+                # *number of batch* tensors with shape=(batch size, img)
+                x_minibatch = tf.unstack(minibatch[0], axis=0)
+                y_minibatch = tf.unstack(minibatch[1], axis=0)  # same here, with labels
+
+                for x, y in zip(x_minibatch, y_minibatch):  # iterate over batches
+                    with tf.GradientTape() as tape:
+                        y_pred = model(x)
+                        loss = model.compiled_loss(y, y_pred)
+                    model.compiled_metrics.update_state(y, y_pred)  # log the loss and accuracy
+                    partners_optimizers[p_id].minimize(loss, model.trainable_weights,
+                                                       tape=tape)  # perform local optimizations
+                # get the gradient as theta_before_minibatch - theta_after_minibatch
+                for grad_per_layer, w_old, w_new in zip(partners_grads[p_id], model_stateholder,
+                                                        model.trainable_weights):
+                    grad_per_layer.assign((w_old - w_new))
+
+                for model_w, old_w in zip(model.trainable_weights,
+                                          model_stateholder):  # reset the model's weights for the next partner
+                    model_w.assign(old_w.read_value())
+
+            # at the end of the minibatch, aggregate all the local grads
+            for i, grads_per_layer in enumerate(zip(*partners_grads)):
+                global_grad[i].assign(tf.tensordot(grads_per_layer, aggregation_weights, [0, 0]))
+
+            # perform one optimization update using the aggregated gradient
+            model.optimizer.apply_gradients(
+                zip(global_grad, model.trainable_weights))
+
+            # Execution
+
+        self.timer = time.time()
+        for e in range(self.epoch_count):
+            self.epoch_timer = time.time()
+            for partners_minibatches in zip(*self.train_dataset):  # <- partners_minibatches == [(x, y)] * nb_partners
+                if self.reset_local_optims:
+                    self.partners_optimizers = [self.model.optimizer.from_config(self.model.optimizer.get_config()) for
+                                                _ in
+                                                self.partners_list]  # reset the local optimizers
+                fit_minibatch(self.model,
+                              self.model_stateholder,
+                              partners_minibatches,
+                              self.partners_optimizers,
+                              self.partners_grads,
+                              self.global_grad,
+                              self.aggregation_weights)
+            epoch_history = self.get_epoch_history()  # compute val and train acc and loss.
+            # add the epoch _history to self _history, and log epoch number, and metrics values.
+            self.log_epoch(e, epoch_history)
+            self.epochs_index += 1
+            if self.early_stop():
+                break
+
+        self.log_end_training()

--- a/mplc/multi_partner_learning/fast_mpl.py
+++ b/mplc/multi_partner_learning/fast_mpl.py
@@ -583,7 +583,8 @@ class FastFedGDO(FastFedAvg):
     In this version we use a local optimizer (partner-specific) to do several minimization steps of the local-loss
     during a minibatch. We use the sum of these weighs-updates as the gradient which is sent to the global optimizer.
     The global optimizer aggregates these gradients-like which have been sent by the partners,
-    and performs a optimization step with this aggregated gradient.
+    and performs a optimization step with this aggregated gradient. FedGDO stands for Federated Gradient with double
+    optimizers.
     """
     name = 'FastFedGDO'
 
@@ -642,8 +643,7 @@ class FastFedGDO(FastFedAvg):
             model.optimizer.apply_gradients(
                 zip(global_grad, model.trainable_weights))
 
-            # Execution
-
+        # Execution
         self.timer = time.time()
         for e in range(self.epoch_count):
             self.epoch_timer = time.time()

--- a/mplc/multi_partner_learning/fast_mpl.py
+++ b/mplc/multi_partner_learning/fast_mpl.py
@@ -587,8 +587,9 @@ class FastFedGDO(FastFedAvg):
     """
     name = 'FastFedGDO'
 
-    def __init__(self, scenario, reset_local_optims=False, **kwargs):
+    def __init__(self, scenario, reset_local_optims=False, global_optimiser=None, **kwargs):
         super(FastFedGDO, self).__init__(scenario, **kwargs)
+        self.global_optimiser = global_optimiser
         self.reset_local_optims = reset_local_optims
 
     def init_specific_tf_variable(self):
@@ -599,6 +600,8 @@ class FastFedGDO(FastFedAvg):
         self.global_grad = [tf.Variable(initial_value=w.read_value()) for w in self.model.trainable_weights]
         self.partners_optimizers = [self.model.optimizer.from_config(self.model.optimizer.get_config()) for _ in
                                     self.partners_list]
+        if self.global_optimiser:
+            self.model.compile(optimizer=self.global_optimiser)
 
     def fit(self):
         # TF function definition


### PR DESCRIPTION
This PR follows the draft 235, which was too far behind master. This is a rebased version.  

# New mpl methods:

FedGDO stands for Federated Gradient Double Optimization.

This method is inspired from Federated gradient, but with modification on the local computation of the gradient.
In this version we use a local optimizer (partner-specific) to do several minimization steps of the local-loss
during a minibatch. We use the sum of these weighs-updates as the gradient which is sent to the global optimizer.
The global optimizer aggregates these gradients-like which have been sent by the partners,
and performs a optimization step with this aggregated gradient.
Here three variations of this mpl method are tested.
 - FedGDO with fresh local optimizer at each minibatch
 - FedGDO with persistent local optimizer

The reset of the optimizers can be set via a parameter of the mpl methods. In the same way, a global optimizer different from the local ones can be passed via the mpl arguments. 

These methods are tested on this notebook -> https://colab.research.google.com/drive/1CcQpWRpLGldj3iNR7v7Hv2brdwBP3z7D?usp=sharing

Please note that as I am currently working with the notebook, it can change, and be not fully readable 
Notebook access is currently limited to substra.org, but don't hesitate to come to me for access.